### PR TITLE
Parametrize Nodes and add tree printing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Michael Hatherly <michaelhatherly@gmail.com>"]
 version = "0.1.0"
 
 [deps]
+AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
 tree_sitter_bash_jll = "7332bcdc-bd2a-5999-b4fe-680b85f40771"
 tree_sitter_c_jll = "af41be9f-6c08-5eeb-b278-7a4b044e283f"


### PR DESCRIPTION
This adds pretty printing from `AbstractTrees` and makes it possible to dispatch on nodes as they have distinct types now. Should we parametrize by the language as well? The tests break as they are currently dependent on the printing of the trees, but I wanted to get your thoughts first.