### PR TITLE
ci: streamline test matrix and add package caching

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,32 +14,38 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/master' || github.run_number }}
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
+permissions:
+  actions: write
+  contents: read
+
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
-          - '1.7'
-          - '1.8'
+          - 'lts'
+          - '1'
           - 'nightly'
         os:
           - ubuntu-latest
-          - macOS-latest
+          - macos-latest
           - windows-latest
-        arch:
-          - x64
+        include:
+          # Minimum version (Linux only)
+          - version: 'min'
+            os: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v4
 
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
+
+      - uses: julia-actions/cache@v2
 
       - uses: julia-actions/julia-buildpkg@v1
 


### PR DESCRIPTION
Simplify the CI test matrix to focus on key Julia versions (min, lts, stable, nightly) instead of testing every minor version. Run minimum version tests only on Linux to reduce CI time while maintaining compatibility coverage.

Add julia-actions/cache to speed up builds by caching Julia packages, artifacts, and registries between runs. This requires actions:write permission for automatic cache cleanup.

Remove explicit architecture specification to use runner defaults, which now includes ARM64 on macos-latest runners.