### PR TITLE
ci(docs): fix outdated badges and codecov upload

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -56,4 +56,5 @@ jobs:
 
       - uses: codecov/codecov-action@v5
         with:
-          file: lcov.info
+          files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 *Julia bindings for [tree-sitter](https://github.com/tree-sitter/tree-sitter) &mdash;
 "An incremental parsing system for programming tools."*
 
-[![Build Status](https://travis-ci.org/MichaelHatherly/TreeSitter.jl.svg?branch=1.4)](https://travis-ci.org/MichaelHatherly/TreeSitter.jl)
-[![Codecov](https://codecov.io/gh/MichaelHatherly/TreeSitter.jl/branch/1.4/graph/badge.svg)](https://codecov.io/gh/MichaelHatherly/TreeSitter.jl)
+[![CI](https://github.com/MichaelHatherly/TreeSitter.jl/actions/workflows/CI.yml/badge.svg?branch=master)](https://github.com/MichaelHatherly/TreeSitter.jl/actions/workflows/CI.yml)
+[![Codecov](https://codecov.io/gh/MichaelHatherly/TreeSitter.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/MichaelHatherly/TreeSitter.jl)
 
 ## Installation
 


### PR DESCRIPTION
Replace Travis CI badge with GitHub Actions badge and update Codecov badge to reference master branch instead of obsolete 1.4 branch. Add CODECOV_TOKEN authentication to fix coverage upload failures on protected branches (codecov-action@v5 requirement).