### PR TITLE
docs(readme): update installation and fix examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update README with installation instructions and current parser examples [#30]
 - Add code formatting enforcement to CI and format codebase [#29]
 - Upgrade tree-sitter parsers to latest versions [#25]
 - Streamline CI test matrix and add package caching [#26]
@@ -43,3 +44,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#27]: https://github.com/MichaelHatherly/TreeSitter.jl/issues/27
 [#28]: https://github.com/MichaelHatherly/TreeSitter.jl/issues/28
 [#29]: https://github.com/MichaelHatherly/TreeSitter.jl/issues/29
+[#30]: https://github.com/MichaelHatherly/TreeSitter.jl/issues/30

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@
 
 ## Installation
 
-This package is not registered yet and so can be installed using:
+This package is registered in the Julia General registry and can be installed using:
 
 ```
-pkg> add https://github.com/MichaelHatherly/TreeSitter.jl
+pkg> add TreeSitter
 ```
 
 ## Usage
@@ -28,22 +28,27 @@ julia> ast = parse(c, "int x;")
 julia> json = Parser(:json)
 Parser(Language(:json))
 
-julia> ast = parse(json, "{1: [2]}")
-(document (object (pair key: (number) value: (array (number)))))
+julia> ast = parse(json, "{\"key\": [1, 2]}")
+(document (object (pair key: (string (string_content)) value: (array (number) (number)))))
 
 julia> traverse(ast) do node, enter
            if enter
                @show node
            end
        end
-node = (document (object (pair key: (number) value: (array (number)))))
-node = (object (pair key: (number) value: (array (number))))
+node = (document (object (pair key: (string (string_content)) value: (array (number) (number)))))
+node = (object (pair key: (string (string_content)) value: (array (number) (number))))
 node = ("{")
-node = (pair key: (number) value: (array (number)))
-node = (number)
+node = (pair key: (string (string_content)) value: (array (number) (number)))
+node = (string (string_content))
+node = ("\"")
+node = (string_content)
+node = ("\"")
 node = (":")
-node = (array (number))
+node = (array (number) (number))
 node = ("[")
+node = (number)
+node = (",")
 node = (number)
 node = ("]")
 node = ("}")

--- a/justfile
+++ b/justfile
@@ -7,7 +7,7 @@ changelog-install:
     julia --project=.ci -e 'using Pkg; Pkg.instantiate()'
 
 # Update changelog link references
-changelog-links:
+changelog:
     julia --project=.ci .ci/changelog.jl
 
 # Format code with JuliaFormatter


### PR DESCRIPTION
Update README to reflect that the package is now registered in the Julia General registry, changing installation instructions from the GitHub URL to the simpler `pkg> add TreeSitter` command.

Also fix the JSON parsing example to use valid JSON (keys must be strings) and update all example outputs to match the current parser behavior, which now includes more detailed node types like `string_content` within `string` nodes.