### PR TITLE
test(coverage): add error path tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Streamline CI test matrix and add package caching [#26]
 - Update CEnum compatibility to 0.5 [#24]
 - Reorganize test suite into focused test files and improve test coverage [#31]
+- Improve test coverage for error handling paths [#32]
 
 ### Fixed
 
@@ -48,3 +49,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#29]: https://github.com/MichaelHatherly/TreeSitter.jl/issues/29
 [#30]: https://github.com/MichaelHatherly/TreeSitter.jl/issues/30
 [#31]: https://github.com/MichaelHatherly/TreeSitter.jl/issues/31
+[#32]: https://github.com/MichaelHatherly/TreeSitter.jl/issues/32

--- a/test/nodes.jl
+++ b/test/nodes.jl
@@ -114,6 +114,18 @@ end
         params = TreeSitter.child(func_def, "parametere")
         @test TreeSitter.node_type(params) == "parameter_list"
     end
+
+    @testset "Invalid field name" begin
+        p = Parser(:c)
+        tree = parse(p, "int main(void) { return 0; }")
+        root_node = TreeSitter.root(tree)
+
+        func_def = TreeSitter.child(root_node, 1)
+        @test TreeSitter.node_type(func_def) == "function_definition"
+
+        # Try to access a non-existent field
+        @test_throws ArgumentError TreeSitter.child(func_def, "nonexistent_field")
+    end
 end
 
 @testset "Node Equality" begin

--- a/test/queries.jl
+++ b/test/queries.jl
@@ -111,3 +111,12 @@ end
     @test out[4] == ("type", "void")
     @test out[5] == ("comment", "// comment")
 end
+
+@testset "Query Syntax Errors" begin
+    @testset "Invalid syntax" begin
+        # Malformed query syntax should throw QueryException
+        @test_throws TreeSitter.QueryException query```
+        (invalid_node_type_that_doesnt_exist) @x
+        ```julia
+    end
+end


### PR DESCRIPTION
Add tests for previously uncovered error handling paths to improve overall test coverage. This includes tests for invalid field name lookups and malformed query syntax validation.