### PR TITLE
feat(integration): add AbstractTrees.jl support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add AbstractTrees.jl integration for tree traversal and printing [#35]
 - Add `any-of?` and `has-ancestor?` query predicates with argument validation [#33]
 - Add changelog tooling with automated link generation and CI validation [#28]
 
@@ -54,3 +55,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#31]: https://github.com/MichaelHatherly/TreeSitter.jl/issues/31
 [#32]: https://github.com/MichaelHatherly/TreeSitter.jl/issues/32
 [#33]: https://github.com/MichaelHatherly/TreeSitter.jl/issues/33
+[#34]: https://github.com/MichaelHatherly/TreeSitter.jl/issues/34
+[#35]: https://github.com/MichaelHatherly/TreeSitter.jl/issues/35

--- a/Project.toml
+++ b/Project.toml
@@ -4,11 +4,13 @@ authors = ["Michael Hatherly <michaelhatherly@gmail.com>"]
 version = "0.1.0"
 
 [deps]
+AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 tree_sitter_jll = "695101d5-1b81-5434-9529-70430e482717"
 
 [compat]
+AbstractTrees = "0.4"
 CEnum = "0.4, 0.5"
 Libdl = "1"
 julia = "1.6"

--- a/src/TreeSitter.jl
+++ b/src/TreeSitter.jl
@@ -5,5 +5,6 @@ export parse, traverse, children, named_children, @query_cmd
 
 include("api.jl")
 include("interface.jl")
+include("abstracttrees.jl")
 
 end # module

--- a/src/abstracttrees.jl
+++ b/src/abstracttrees.jl
@@ -1,0 +1,7 @@
+import AbstractTrees
+
+AbstractTrees.children(n::Node) = TreeSitter.children(n)
+
+function AbstractTrees.printnode(io::IO, n::Node)
+    print(io, node_type(n))
+end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 tree_sitter_bash_jll = "7332bcdc-bd2a-5999-b4fe-680b85f40771"
 tree_sitter_c_jll = "af41be9f-6c08-5eeb-b278-7a4b044e283f"

--- a/test/abstracttrees.jl
+++ b/test/abstracttrees.jl
@@ -1,0 +1,29 @@
+import AbstractTrees
+
+@testset "AbstractTrees" begin
+    parser = Parser(:julia)
+    tree = parse(parser, "f(x) = x + 1")
+    node = TreeSitter.root(tree)
+
+    @testset "children interface" begin
+        # Test that AbstractTrees.children works
+        kids = collect(AbstractTrees.children(node))
+        @test length(kids) > 0
+        @test all(k -> k isa Node, kids)
+
+        # Should match TreeSitter.children
+        ts_kids = collect(TreeSitter.children(node))
+        @test kids == ts_kids
+    end
+
+    @testset "print_tree" begin
+        # Test that print_tree produces output without errors
+        io = IOBuffer()
+        AbstractTrees.print_tree(io, node)
+        output = String(take!(io))
+
+        @test !isempty(output)
+        @test contains(output, "source_file")
+        @test contains(output, "assignment")
+    end
+end

--- a/test/parsing.jl
+++ b/test/parsing.jl
@@ -13,25 +13,25 @@ import tree_sitter_bash_jll,
     tree_sitter_rust_jll,
     tree_sitter_typescript_jll
 
-const LANGUAGE_JLLS = [
-    (:bash, tree_sitter_bash_jll),
-    (:c, tree_sitter_c_jll),
-    (:cpp, tree_sitter_cpp_jll),
-    (:go, tree_sitter_go_jll),
-    (:html, tree_sitter_html_jll),
-    (:java, tree_sitter_java_jll),
-    (:javascript, tree_sitter_javascript_jll),
-    (:json, tree_sitter_json_jll),
-    (:julia, tree_sitter_julia_jll),
-    (:php, tree_sitter_php_jll),
-    (:python, tree_sitter_python_jll),
-    (:ruby, tree_sitter_ruby_jll),
-    (:rust, tree_sitter_rust_jll),
-    (:typescript, tree_sitter_typescript_jll),
-]
-
 @testset "Load & Parse" begin
-    for (lang_name, lang_jll) in LANGUAGE_JLLS
+    language_jlls = [
+        (:bash, tree_sitter_bash_jll),
+        (:c, tree_sitter_c_jll),
+        (:cpp, tree_sitter_cpp_jll),
+        (:go, tree_sitter_go_jll),
+        (:html, tree_sitter_html_jll),
+        (:java, tree_sitter_java_jll),
+        (:javascript, tree_sitter_javascript_jll),
+        (:json, tree_sitter_json_jll),
+        (:julia, tree_sitter_julia_jll),
+        (:php, tree_sitter_php_jll),
+        (:python, tree_sitter_python_jll),
+        (:ruby, tree_sitter_ruby_jll),
+        (:rust, tree_sitter_rust_jll),
+        (:typescript, tree_sitter_typescript_jll),
+    ]
+
+    for (lang_name, lang_jll) in language_jlls
         @testset "$lang_name" begin
             p = Parser(lang_jll)
             tree = parse(p, "")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,4 +5,5 @@ using TreeSitter, Test
     include("traversal.jl")
     include("nodes.jl")
     include("queries.jl")
+    include("abstracttrees.jl")
 end


### PR DESCRIPTION
Implements AbstractTrees.jl interface for Node objects to enable tree traversal and pretty-printing using the AbstractTrees ecosystem.

This integration allows users to leverage AbstractTrees.print_tree() and other AbstractTrees utilities for exploring parse tree structures, making TreeSitter.jl nodes compatible with the broader Julia tree manipulation ecosystem.

The implementation defines:
- AbstractTrees.children() mapping to TreeSitter.children()
- AbstractTrees.printnode() for custom node display formatting

Adds comprehensive test coverage for the AbstractTrees interface including validation of children iteration and print_tree output.

Closes #1