### PR TITLE
feat(parser): add multi-parser variant support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add multi-parser support for JLL packages with multiple language variants [#36]
 - Add AbstractTrees.jl integration for tree traversal and printing [#35]
 - Add `any-of?` and `has-ancestor?` query predicates with argument validation [#33]
 - Add changelog tooling with automated link generation and CI validation [#28]
@@ -57,3 +58,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#33]: https://github.com/MichaelHatherly/TreeSitter.jl/issues/33
 [#34]: https://github.com/MichaelHatherly/TreeSitter.jl/issues/34
 [#35]: https://github.com/MichaelHatherly/TreeSitter.jl/issues/35
+[#36]: https://github.com/MichaelHatherly/TreeSitter.jl/issues/36

--- a/README.md
+++ b/README.md
@@ -132,3 +132,37 @@ pkg> add tree_sitter_julia_jll tree_sitter_python_jll
 Additional languages can be added by writing new `jll` packages to wrap the
 upstream parsers: see [Yggdrasil](https://github.com/JuliaPackaging/Yggdrasil)
 for details.
+
+## Multiple Parsers per Language
+
+Some language packages provide multiple parser variants. For example, `tree_sitter_php_jll` provides both `php` (with HTML support) and `php_only` (pure PHP) parsers.
+
+Discover available parsers:
+```julia
+julia> using TreeSitter, tree_sitter_php_jll
+
+julia> list_parsers(tree_sitter_php_jll)
+2-element Vector{Symbol}:
+ :php
+ :php_only
+```
+
+Use a specific parser variant:
+```julia
+julia> # Default parser (php with HTML support)
+julia> p1 = Parser(tree_sitter_php_jll)
+Parser(Language(:php))
+
+julia> # PHP-only variant
+julia> p2 = Parser(tree_sitter_php_jll, :php_only)
+Parser(Language(:php_only))
+```
+
+The same variant parameter works for `Language` and `Query` constructors:
+```julia
+julia> lang = Language(tree_sitter_php_jll, :php_only)
+Language(:php_only)
+
+julia> query = Query(tree_sitter_php_jll, "(identifier) @id", :php_only)
+Query(Language(:php_only))
+```

--- a/src/TreeSitter.jl
+++ b/src/TreeSitter.jl
@@ -2,6 +2,7 @@ module TreeSitter
 
 export Parser, Tree, Node, Language, Query
 export parse, traverse, children, named_children, @query_cmd
+export list_parsers
 
 include("api.jl")
 include("interface.jl")

--- a/test/parsing.jl
+++ b/test/parsing.jl
@@ -100,6 +100,32 @@ end
         @test string(tree) ==
               "(program (php_tag) (expression_statement (assignment_expression left: (variable_name (name)) right: (integer))) (text_interpolation (php_end_tag)))"
     end
+    @testset "php multi-parser" begin
+        # Test list_parsers
+        parsers = list_parsers(tree_sitter_php_jll)
+        @test :php in parsers
+        @test :php_only in parsers
+        @test length(parsers) == 2
+
+        # Test default parser (php)
+        p1 = Parser(tree_sitter_php_jll)
+        @test p1.language.name == :php
+        tree1 = parse(p1, "<?php\n\$x = 1;\n?>")
+        @test string(tree1) ==
+              "(program (php_tag) (expression_statement (assignment_expression left: (variable_name (name)) right: (integer))) (text_interpolation (php_end_tag)))"
+
+        # Test php_only variant
+        p2 = Parser(tree_sitter_php_jll, :php_only)
+        @test p2.language.name == :php_only
+        tree2 = parse(p2, "\$x = 1;")
+        @test string(tree2) ==
+              "(program (expression_statement (assignment_expression left: (variable_name (name)) right: (integer))))"
+
+        # Test that parsers produce different results for same input
+        tree_default = parse(p1, "\$x = 1;")
+        tree_only = parse(p2, "\$x = 1;")
+        @test string(tree_default) != string(tree_only)
+    end
     @testset "python" begin
         p = Parser(:python)
         tree = parse(p, "1 < 2 and 2 < 3")


### PR DESCRIPTION
Some language JLL packages provide multiple parser variants (e.g., tree_sitter_php_jll offers both php with HTML support and php_only for pure PHP). This change adds the ability to discover and use specific parser variants.

Add list_parsers() function to discover available variants in a JLL module by scanning for libtreesitter_*_handle symbols. Add optional variant parameter to Language, Parser, and Query constructors to specify which parser variant to use. When variant is not specified, the default parser name is inferred from the JLL module name.

Include comprehensive tests for PHP multi-parser support and update documentation with usage examples.