### PR TITLE
feat(query): add predicate metadata and property system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add query predicate metadata system with `#set!` directives, `#is?`/`#is-not?` property checks, and quantified predicates for multi-capture patterns [#37]
 - Add multi-parser support for JLL packages with multiple language variants [#36]
 - Add AbstractTrees.jl integration for tree traversal and printing [#35]
 - Add `any-of?` and `has-ancestor?` query predicates with argument validation [#33]
@@ -59,3 +60,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#34]: https://github.com/MichaelHatherly/TreeSitter.jl/issues/34
 [#35]: https://github.com/MichaelHatherly/TreeSitter.jl/issues/35
 [#36]: https://github.com/MichaelHatherly/TreeSitter.jl/issues/36
+[#37]: https://github.com/MichaelHatherly/TreeSitter.jl/issues/37

--- a/README.md
+++ b/README.md
@@ -166,3 +166,45 @@ Language(:php_only)
 julia> query = Query(tree_sitter_php_jll, "(identifier) @id", :php_only)
 Query(Language(:php_only))
 ```
+
+## Query Predicates and Metadata
+
+TreeSitter.jl supports tree-sitter query predicates for filtering matches and attaching metadata to patterns.
+
+### Supported Filtering Predicates
+
+**String Comparison:**
+- `#eq?` - String equality: `(#eq? @var "foo")`
+- `#not-eq?` - String inequality: `(#not-eq? @method "constructor")`
+- `#any-of?` - Multi-value equality: `(#any-of? @type "int" "void" "char")`
+
+**Pattern Matching:**
+- `#match?` - Regex match: `(#match? @lowercase "^[a-z]+$")`
+- `#not-match?` - Negated regex: `(#not-match? @public "^_")`
+
+**Node Properties:**
+- `#is?` - Property assertion: `(#is? @node "named")`
+- `#is-not?` - Negated property: `(#is-not? @node "extra")`
+
+Only built-in properties are checked: `named`, `missing`, `extra`
+
+**Tree Structure:**
+- `#has-ancestor?` - Ancestor check: `(#has-ancestor? @indexer index_expression)`
+
+**Quantified Predicates:**
+
+For patterns with quantified captures (e.g., `(comment)+ @comments`), these predicates check if the condition holds for ANY of the captured nodes:
+
+- `#any-eq?` - ANY capture equals value: `(#any-eq? @comments "// TODO")`
+- `#any-not-eq?` - ANY capture not equal: `(#any-not-eq? @ids "reserved")`
+- `#any-match?` - ANY capture matches regex: `(#any-match? @comments "TODO")`
+- `#any-not-match?` - ANY capture doesn't match: `(#any-not-match? @lines "^\\s*$")`
+
+Example usage:
+```julia
+# Match comment blocks where at least one comment contains "TODO"
+q = query```
+((comment)+ @comments
+ (#any-match? @comments "TODO"))
+```julia
+```

--- a/test/queries.jl
+++ b/test/queries.jl
@@ -158,6 +158,289 @@ import tree_sitter_julia_jll, tree_sitter_javascript_jll, tree_sitter_c_jll
         @test ("indexer", "begin") in out
         @test ("indexer", "end") in out
     end
+
+    @testset "not-match? predicate" begin
+        p = Parser(tree_sitter_julia_jll)
+        source = """
+        _private = 1
+        public_var = 2
+        another = 3
+        _internal = 4
+        """
+        tree = parse(p, source)
+
+        # Match identifiers that DON'T start with underscore
+        q = query```
+        ((identifier) @public
+         (#not-match? @public "^_"))
+        ```julia
+
+        out = []
+        for capture in TreeSitter.each_capture(tree, q, source)
+            literal = TreeSitter.slice(source, capture.node)
+            push!(out, literal)
+        end
+
+        # Should match public_var and another, but not _private or _internal
+        @test "public_var" in out
+        @test "another" in out
+        @test !("_private" in out)
+        @test !("_internal" in out)
+    end
+
+    @testset "is? predicate - named property" begin
+        p = Parser(tree_sitter_c_jll)
+        source = "int x = 1 + 2;"
+        tree = parse(p, source)
+
+        # Match only named nodes (excludes punctuation like '=', ';')
+        q = query```
+        ((_ ) @node
+         (#is? @node "named"))
+        ```c
+
+        out = []
+        for capture in TreeSitter.each_capture(tree, q, source)
+            literal = TreeSitter.slice(source, capture.node)
+            push!(out, literal)
+        end
+
+        # Should include 'int', 'x', '1', '2', '1 + 2', but not '=' or ';'
+        @test "=" ∉ out
+        @test ";" ∉ out
+        @test "int" in out || "int x = 1 + 2;" in out  # May capture parent nodes
+    end
+
+    @testset "is-not? predicate - named property" begin
+        p = Parser(tree_sitter_c_jll)
+        source = "int x;"
+        tree = parse(p, source)
+
+        # Match only named nodes - is-not? should filter them out for "extra" property
+        # (there are no extra nodes in this example, so result should be empty)
+        q = query```
+        ((identifier) @node
+         (#is-not? @node "extra"))
+        ```c
+
+        out = []
+        for capture in TreeSitter.each_capture(tree, q, source)
+            literal = TreeSitter.slice(source, capture.node)
+            push!(out, literal)
+        end
+
+        # Should match identifiers (they are not extra)
+        @test "x" in out
+        @test length(out) >= 1
+    end
+
+    @testset "Anonymous nodes - literal matching" begin
+        p = Parser(tree_sitter_c_jll)
+        source = "int x;"
+        tree = parse(p, source)
+
+        # Match literal semicolon (anonymous node)
+        q = query```
+        (";" @semi)
+        ```c
+
+        found = false
+        for capture in TreeSitter.each_capture(tree, q, source)
+            # Verify semicolon is anonymous (not named)
+            @test !TreeSitter.is_named(capture.node)
+            @test TreeSitter.slice(source, capture.node) == ";"
+            found = true
+        end
+        @test found  # Ensure we actually captured something
+    end
+
+    @testset "set! directive - metadata storage" begin
+        p = Parser(tree_sitter_julia_jll)
+        source = "f(x) = x + 1"
+        tree = parse(p, source)
+
+        # Query with set! directives
+        q = query```
+        ((identifier) @var
+         (#set! "priority" "100")
+         (#set! "scope" "local"))
+        ```julia
+
+        # Verify metadata was parsed at construction
+        props = TreeSitter.property_settings(q, 1)
+        @test length(props) == 2
+        @test any(p -> p.key == "priority" && p.value == "100", props)
+        @test any(p -> p.key == "scope" && p.value == "local", props)
+
+        # Verify set! doesn't filter matches
+        out = []
+        for capture in TreeSitter.each_capture(tree, q, source)
+            literal = TreeSitter.slice(source, capture.node)
+            push!(out, literal)
+        end
+        @test length(out) > 0  # Should have matches
+
+        # Test convenience accessor
+        for m in eachmatch(q, tree)
+            priority = TreeSitter.property(q, m, "priority")
+            @test priority == "100"
+            scope = TreeSitter.property(q, m, "scope")
+            @test scope == "local"
+        end
+    end
+
+    @testset "is? predicate - property assertions storage" begin
+        p = Parser(tree_sitter_julia_jll)
+        q = query```
+        ((identifier) @var
+         (#is? @var "named"))
+        ```julia
+
+        # Verify property assertions were parsed
+        props = TreeSitter.property_predicates(q, 1)
+        @test length(props) == 1
+        @test props[1][1].key == "named"
+        @test props[1][2] == true  # Positive assertion
+    end
+
+    @testset "any-match? predicate - quantified captures" begin
+        p = Parser(tree_sitter_c_jll)
+
+        # Source with multiple comments, one contains "TODO"
+        source = """
+        // NOTE: first
+        // TODO: second
+        // INFO: third
+        """
+        tree = parse(p, source)
+
+        # Match comment groups where ANY comment contains "TODO"
+        q = query```
+        ((comment)+ @comments
+         (#any-match? @comments "TODO"))
+        ```c
+
+        out = []
+        for capture in TreeSitter.each_capture(tree, q, source)
+            literal = TreeSitter.slice(source, capture.node)
+            push!(out, literal)
+        end
+
+        # Should capture all three comments since one contains TODO
+        @test length(out) == 3
+        @test "// NOTE: first" in out
+        @test "// TODO: second" in out
+        @test "// INFO: third" in out
+    end
+
+    @testset "any-match? predicate - no match" begin
+        p = Parser(tree_sitter_c_jll)
+
+        # Source with multiple comments, none contains "TODO"
+        source = """
+        // NOTE: first
+        // INFO: second
+        """
+        tree = parse(p, source)
+
+        # Match comment groups where ANY comment contains "TODO"
+        q = query```
+        ((comment)+ @comments
+         (#any-match? @comments "TODO"))
+        ```c
+
+        out = []
+        for capture in TreeSitter.each_capture(tree, q, source)
+            literal = TreeSitter.slice(source, capture.node)
+            push!(out, literal)
+        end
+
+        # Should capture nothing since no comment contains TODO
+        @test length(out) == 0
+    end
+
+    @testset "any-not-match? predicate" begin
+        p = Parser(tree_sitter_c_jll)
+
+        # Source where not all comments match a pattern
+        source = """
+        // TODO: first
+        // INFO: second
+        """
+        tree = parse(p, source)
+
+        # Match comment groups where ANY comment doesn't contain "TODO"
+        q = query```
+        ((comment)+ @comments
+         (#any-not-match? @comments "TODO"))
+        ```c
+
+        out = []
+        for capture in TreeSitter.each_capture(tree, q, source)
+            literal = TreeSitter.slice(source, capture.node)
+            push!(out, literal)
+        end
+
+        # Should match because second comment doesn't contain TODO
+        @test length(out) == 2
+    end
+
+    @testset "any-eq? predicate" begin
+        p = Parser(tree_sitter_c_jll)
+
+        # Source with consecutive comments (actually adjacent)
+        source = """
+        // comment one
+        // comment two
+        // comment three
+        """
+        tree = parse(p, source)
+
+        # Match comment groups where ANY comment equals a specific string
+        q = query```
+        ((comment)+ @comments
+         (#any-eq? @comments "// comment two"))
+        ```c
+
+        out = []
+        for capture in TreeSitter.each_capture(tree, q, source)
+            literal = TreeSitter.slice(source, capture.node)
+            push!(out, literal)
+        end
+
+        # Should capture all three comments since one equals the target
+        @test length(out) == 3
+        @test "// comment one" in out
+        @test "// comment two" in out
+        @test "// comment three" in out
+    end
+
+    @testset "any-not-eq? predicate" begin
+        p = Parser(tree_sitter_c_jll)
+
+        # Source with consecutive comments all with same content
+        source = """
+        // same
+        // same
+        // same
+        """
+        tree = parse(p, source)
+
+        # Match comment groups where ANY comment is not "// same"
+        q = query```
+        ((comment)+ @comments
+         (#any-not-eq? @comments "// same"))
+        ```c
+
+        out = []
+        for capture in TreeSitter.each_capture(tree, q, source)
+            literal = TreeSitter.slice(source, capture.node)
+            push!(out, literal)
+        end
+
+        # Should not match since all comments equal "// same"
+        @test length(out) == 0
+    end
 end
 
 @testset "Loading Query Files" begin
@@ -189,4 +472,40 @@ end
         (invalid_node_type_that_doesnt_exist) @x
         ```julia
     end
+end
+
+@testset "Unknown property warnings" begin
+    # Test 1: Unknown property triggers warning
+    @test_logs (:warn, r"unimplemented properties.*nmed") begin
+        Query(tree_sitter_c_jll, "((identifier) @node (#is? @node \"nmed\"))")
+    end
+
+    # Test 2: Builtin properties don't warn
+    @test_logs begin
+        Query(tree_sitter_c_jll, "((identifier) @node (#is? @node \"named\"))")
+    end
+
+    # Test 3: Known unimplemented "local" doesn't warn
+    @test_logs begin
+        Query(tree_sitter_c_jll, "((identifier) @node (#is-not? @node \"local\"))")
+    end
+
+    # Test 4: Multiple unknown properties shown sorted
+    @test_logs (:warn, r"bar, foo") begin
+        Query(
+            tree_sitter_c_jll,
+            """
+((identifier) @x (#is? @x "foo"))
+((identifier) @y (#is? @y "bar"))
+""",
+        )
+    end
+
+    # Test 5: Verify unknown_properties field is populated
+    q = @test_logs (:warn,) Query(
+        tree_sitter_c_jll,
+        "((identifier) @x (#is? @x \"unknown\"))",
+    )
+    @test "unknown" in q.unknown_properties
+    @test length(q.unknown_properties) == 1
 end


### PR DESCRIPTION
Enables attaching metadata to query patterns via `#set!` directives, which store key-value pairs accessible at match time. Adds `#is?` and `#is-not?` predicates for filtering nodes by built-in properties (`named`, `missing`, `extra`).

Implements quantified predicates (`#any-match?`, `#any-not-match?`, `#any-eq?`, `#any-not-eq?`) for patterns with multi-capture operators like `(comment)+ @comments`. These check if ANY captured node matches the condition.

Adds `#not-match?` predicate for negated regex matching.

Metadata is parsed once at query construction and stored in the `Query` object for O(1) pattern-indexed lookup. Property accessor functions provide convenient access to metadata from `QueryMatch` and `QueryCapture` objects.