### PR TITLE
feat(parser): load parsers from local grammar repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Support loading parsers from local tree-sitter grammar repositories [#43]
+
 ## [v0.2.2] - 2026-01-14
 
 ### Added
@@ -80,3 +84,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#37]: https://github.com/MichaelHatherly/TreeSitter.jl/issues/37
 [#41]: https://github.com/MichaelHatherly/TreeSitter.jl/issues/41
 [#42]: https://github.com/MichaelHatherly/TreeSitter.jl/issues/42
+[#43]: https://github.com/MichaelHatherly/TreeSitter.jl/issues/43

--- a/Project.toml
+++ b/Project.toml
@@ -6,12 +6,14 @@ version = "0.2.2"
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 tree_sitter_jll = "695101d5-1b81-5434-9529-70430e482717"
 
 [compat]
 AbstractTrees = "0.4"
 CEnum = "0.4, 0.5"
+JSON = "0.21, 1"
 Libdl = "1"
 julia = "1.6"
 tree_sitter_jll = "0.25"

--- a/README.md
+++ b/README.md
@@ -167,6 +167,32 @@ julia> query = Query(tree_sitter_php_jll, "(identifier) @id", :php_only)
 Query(Language(:php_only))
 ```
 
+## Local Grammar Repositories
+
+For grammars not yet packaged as JLLs, load parsers directly from local tree-sitter grammar repositories:
+
+```julia
+# Clone and build the grammar
+# $ git clone https://github.com/tree-sitter/tree-sitter-python
+# $ cd tree-sitter-python && tree-sitter build
+
+using TreeSitter
+parser = Parser("/path/to/tree-sitter-python")
+tree = parse(parser, "def foo(): pass")
+```
+
+**Requirements:**
+- Repository must contain `tree-sitter.json` (tree-sitter v0.21+ format)
+- Shared library must be built (`tree-sitter build` or `make`)
+
+**Multi-grammar repositories:**
+```julia
+# tree-sitter-php has both :php and :php_only variants
+parser = Parser("/path/to/tree-sitter-php", :php_only)
+```
+
+Query files from the repository's `queries/` directory are automatically loaded.
+
 ## Query Predicates and Metadata
 
 TreeSitter.jl supports tree-sitter query predicates for filtering matches and attaching metadata to patterns.

--- a/test/local_grammar.jl
+++ b/test/local_grammar.jl
@@ -1,0 +1,163 @@
+using TreeSitter, Test
+using TreeSitter: API
+import tree_sitter_json_jll
+
+@testset "Local Grammar" begin
+    @testset "find_shared_lib" begin
+        ext = Sys.iswindows() ? ".dll" : Sys.isapple() ? ".dylib" : ".so"
+
+        mktempdir() do dir
+            # Test primary pattern: name.ext (tree-sitter build output)
+            touch(joinpath(dir, "foo$ext"))
+            @test API.find_shared_lib(dir, :foo) == joinpath(dir, "foo$ext")
+        end
+
+        mktempdir() do dir
+            # Test fallback: libtree-sitter-name.ext
+            touch(joinpath(dir, "libtree-sitter-bar$ext"))
+            @test API.find_shared_lib(dir, :bar) == joinpath(dir, "libtree-sitter-bar$ext")
+        end
+
+        mktempdir() do dir
+            # Test priority: name.ext takes precedence over libtree-sitter-name.ext
+            touch(joinpath(dir, "baz$ext"))
+            touch(joinpath(dir, "libtree-sitter-baz$ext"))
+            @test API.find_shared_lib(dir, :baz) == joinpath(dir, "baz$ext")
+        end
+
+        mktempdir() do dir
+            # Test not found
+            @test API.find_shared_lib(dir, :nonexistent) === nothing
+        end
+    end
+
+    @testset "load_local_queries" begin
+        mktempdir() do dir
+            # Setup: queries/ with .scm files
+            mkdir(joinpath(dir, "queries"))
+            write(joinpath(dir, "queries", "highlights.scm"), "(identifier) @var")
+            write(joinpath(dir, "queries", "tags.scm"), "(function) @func")
+
+            grammar = Dict("name" => "test", "path" => ".")
+            queries = API.load_local_queries(dir, grammar)
+
+            @test queries["highlights"] == "(identifier) @var"
+            @test queries["tags"] == "(function) @func"
+        end
+
+        mktempdir() do dir
+            # Test subpath queries take precedence
+            mkdir(joinpath(dir, "queries"))
+            mkdir(joinpath(dir, "src"))
+            mkdir(joinpath(dir, "src", "queries"))
+            write(joinpath(dir, "queries", "highlights.scm"), "root")
+            write(joinpath(dir, "src", "queries", "highlights.scm"), "subpath")
+
+            grammar = Dict("name" => "test", "path" => "src")
+            queries = API.load_local_queries(dir, grammar)
+
+            # root-level queries/ is checked first
+            @test queries["highlights"] == "root"
+        end
+
+        mktempdir() do dir
+            # Test no queries dir
+            grammar = Dict("name" => "test", "path" => ".")
+            queries = API.load_local_queries(dir, grammar)
+            @test isempty(queries)
+        end
+    end
+
+    @testset "error handling" begin
+        mktempdir() do dir
+            # Missing tree-sitter.json
+            @test_throws ErrorException Language(dir)
+        end
+
+        mktempdir() do dir
+            # Invalid variant
+            write(
+                joinpath(dir, "tree-sitter.json"),
+                """{"grammars": [{"name": "foo", "path": "."}]}""",
+            )
+            @test_throws ErrorException Language(dir, :nonexistent)
+        end
+
+        mktempdir() do dir
+            # Valid JSON but missing shared library
+            write(
+                joinpath(dir, "tree-sitter.json"),
+                """{"grammars": [{"name": "foo", "path": "."}]}""",
+            )
+            @test_throws ErrorException Language(dir)
+        end
+    end
+
+    @testset "integration with JLL fixture" begin
+        # Use existing JLL as fixture to test full path without building
+        mktempdir() do dir
+            ext = Sys.iswindows() ? ".dll" : Sys.isapple() ? ".dylib" : ".so"
+
+            # Create tree-sitter.json
+            write(
+                joinpath(dir, "tree-sitter.json"),
+                """{"grammars": [{"name": "json", "path": "."}]}""",
+            )
+
+            # Symlink JLL library into temp dir
+            jll_lib = tree_sitter_json_jll.libtreesitter_json_path
+            symlink(jll_lib, joinpath(dir, "json$ext"))
+
+            # Create queries dir with test query
+            mkdir(joinpath(dir, "queries"))
+            write(joinpath(dir, "queries", "test.scm"), "(string) @str")
+
+            # Test Language constructor
+            lang = Language(dir)
+            @test lang.name == :json
+            @test haskey(lang.queries, "test")
+            @test lang.queries["test"] == "(string) @str"
+
+            # Test Parser constructor
+            p = Parser(dir)
+            @test p.language.name == :json
+
+            # Test parsing works
+            t = parse(p, """{"a": 1}""")
+            @test TreeSitter.node_type(TreeSitter.root(t)) == "document"
+
+            # Test Query constructor
+            q = Query(dir, "(string) @s")
+            @test q.language.name == :json
+        end
+    end
+
+    @testset "multi-grammar repo" begin
+        mktempdir() do dir
+            ext = Sys.iswindows() ? ".dll" : Sys.isapple() ? ".dylib" : ".so"
+
+            # Create tree-sitter.json with multiple grammars
+            write(
+                joinpath(dir, "tree-sitter.json"),
+                """{
+    "grammars": [
+        {"name": "json", "path": "."},
+        {"name": "jsonc", "path": "jsonc"}
+    ]
+}""",
+            )
+
+            # Setup main grammar
+            jll_lib = tree_sitter_json_jll.libtreesitter_json_path
+            symlink(jll_lib, joinpath(dir, "json$ext"))
+
+            # Default selects first grammar
+            lang = Language(dir)
+            @test lang.name == :json
+
+            # Explicit variant selection
+            lang2 = Language(dir, :json)
+            @test lang2.name == :json
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,4 +6,5 @@ using TreeSitter, Test
     include("nodes.jl")
     include("queries.jl")
     include("abstracttrees.jl")
+    include("local_grammar.jl")
 end


### PR DESCRIPTION
Support loading tree-sitter parsers directly from local grammar repos
for testing grammars not yet packaged as JLLs. Requires tree-sitter.json
(v0.21+ format) and a built shared library. Multi-grammar repos supported
via variant parameter. Query files auto-loaded from queries/ directory.