### PR TITLE
feat: expand tree-sitter C-API surface and raise coverage 70→99%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add node health accessors `has_error`/`has_changes` and byte/point descendant lookup [#50]
+- Add grammar introspection (symbol/field metadata) and query scoping by byte/point range [#50]
+
+### Fixed
+
+- Fix the zero-argument `ts_query_cursor_next_capture` binding signature [#50]
 
 ## [v0.2.3] - 2026-01-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add node health accessors `has_error`/`has_changes` and byte/point descendant lookup [#50]
 - Add grammar introspection (symbol/field metadata) and query scoping by byte/point range [#50]
 - Add `TreeCursor` for stateful traversal with field-name access [#50]
+- Add incremental editing: `edit!`, `copy`, reparse with an old tree, and `changed_ranges` [#50]
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add grammar introspection (symbol/field metadata) and query scoping by byte/point range [#50]
 - Add `TreeCursor` for stateful traversal with field-name access [#50]
 - Add incremental editing: `edit!`, `copy`, reparse with an old tree, and `changed_ranges` [#50]
+- Add parser control: `reset!`, UTF-16 parsing, included ranges, logging, and DOT graph output [#50]
 
 ### Fixed
 
 - Fix the zero-argument `ts_query_cursor_next_capture` binding signature [#50]
 - Fix the `TSTreeCursor` struct layout for the tree-sitter 0.25 ABI [#50]
+- Fix the zero-argument `ts_parser_set_included_ranges` binding signature [#50]
+
+### Removed
+
+- Remove deprecated timeout and cancellation-flag parser bindings, dropped in tree-sitter 0.26 [#50]
 
 ## [v0.2.3] - 2026-01-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add node health accessors `has_error`/`has_changes` and byte/point descendant lookup [#50]
 - Add grammar introspection (symbol/field metadata) and query scoping by byte/point range [#50]
+- Add `TreeCursor` for stateful traversal with field-name access [#50]
 
 ### Fixed
 
 - Fix the zero-argument `ts_query_cursor_next_capture` binding signature [#50]
+- Fix the `TSTreeCursor` struct layout for the tree-sitter 0.25 ABI [#50]
 
 ## [v0.2.3] - 2026-01-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `TreeCursor` for stateful traversal with field-name access [#50]
 - Add incremental editing: `edit!`, `copy`, reparse with an old tree, and `changed_ranges` [#50]
 - Add parser control: `reset!`, UTF-16 parsing, included ranges, logging, and DOT graph output [#50]
+- Add streaming parsing from a callback for sources not held as a single `String` [#50]
 
 ### Fixed
 
 - Fix the zero-argument `ts_query_cursor_next_capture` binding signature [#50]
 - Fix the `TSTreeCursor` struct layout for the tree-sitter 0.25 ABI [#50]
 - Fix the zero-argument `ts_parser_set_included_ranges` binding signature [#50]
+- Fix the `TSInput` struct layout, which was missing the 0.25 `decode` field [#50]
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Add node health accessors `has_error`/`has_changes` and byte/point descendant lookup [#50]
+
 ## [v0.2.3] - 2026-01-27
 
 ### Added
@@ -93,3 +97,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#42]: https://github.com/MichaelHatherly/TreeSitter.jl/issues/42
 [#43]: https://github.com/MichaelHatherly/TreeSitter.jl/issues/43
 [#44]: https://github.com/MichaelHatherly/TreeSitter.jl/issues/44
+[#50]: https://github.com/MichaelHatherly/TreeSitter.jl/issues/50

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 90%
+        threshold: 1%
+    patch:
+      default:
+        target: 90%

--- a/src/api.jl
+++ b/src/api.jl
@@ -132,6 +132,7 @@ struct TSInput
     payload::Ptr{Cvoid}
     read::Ptr{Cvoid}
     encoding::TSInputEncoding
+    decode::Ptr{Cvoid}
 end
 
 @cenum TSLogType::UInt32 begin

--- a/src/api.jl
+++ b/src/api.jl
@@ -244,8 +244,15 @@ function ts_parser_language(self)
     ccall((:ts_parser_language, libtreesitter), Ptr{TSLanguage}, (Ptr{TSParser},), self)
 end
 
-function ts_parser_set_included_ranges()
-    ccall((:ts_parser_set_included_ranges, libtreesitter), Cint, ())
+function ts_parser_set_included_ranges(self, ranges, count)
+    ccall(
+        (:ts_parser_set_included_ranges, libtreesitter),
+        Bool,
+        (Ptr{TSParser}, Ptr{TSRange}, UInt32),
+        self,
+        ranges,
+        count,
+    )
 end
 
 function ts_parser_included_ranges(self, length)
@@ -296,34 +303,6 @@ end
 
 function ts_parser_reset(self)
     ccall((:ts_parser_reset, libtreesitter), Cvoid, (Ptr{TSParser},), self)
-end
-
-function ts_parser_set_timeout_micros(self, timeout)
-    ccall(
-        (:ts_parser_set_timeout_micros, libtreesitter),
-        Cvoid,
-        (Ptr{TSParser}, UInt64),
-        self,
-        timeout,
-    )
-end
-
-function ts_parser_timeout_micros(self)
-    ccall((:ts_parser_timeout_micros, libtreesitter), UInt64, (Ptr{TSParser},), self)
-end
-
-function ts_parser_set_cancellation_flag(self, flag)
-    ccall(
-        (:ts_parser_set_cancellation_flag, libtreesitter),
-        Cvoid,
-        (Ptr{TSParser}, Ptr{Cint}),
-        self,
-        flag,
-    )
-end
-
-function ts_parser_cancellation_flag()
-    ccall((:ts_parser_cancellation_flag, libtreesitter), Ptr{Cint}, ())
 end
 
 function ts_parser_set_logger(self, logger)

--- a/src/api.jl
+++ b/src/api.jl
@@ -162,7 +162,7 @@ end
 struct TSTreeCursor
     tree::Ptr{Cvoid}
     id::Ptr{Cvoid}
-    context::NTuple{2,UInt32}
+    context::NTuple{3,UInt32}
 end
 
 struct TSQueryCapture

--- a/src/api.jl
+++ b/src/api.jl
@@ -814,8 +814,15 @@ function ts_query_cursor_remove_match(arg1, id)
     )
 end
 
-function ts_query_cursor_next_capture()
-    ccall((:ts_query_cursor_next_capture, libtreesitter), Cint, ())
+function ts_query_cursor_next_capture(self, match, capture_index)
+    ccall(
+        (:ts_query_cursor_next_capture, libtreesitter),
+        Bool,
+        (Ptr{TSQueryCursor}, Ptr{TSQueryMatch}, Ptr{UInt32}),
+        self,
+        match,
+        capture_index,
+    )
 end
 
 function ts_language_symbol_count(lang)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -204,6 +204,36 @@ first_child_for_byte(n::Node, byte::Integer) =
 first_named_child_for_byte(n::Node, byte::Integer) =
     Node(API.ts_node_first_named_child_for_byte(n.ptr, byte - 1), n.tree)
 
+function child_by_field_id(n::Node, field_id::Integer)
+    result = Node(API.ts_node_child_by_field_id(n.ptr, field_id), n.tree)
+    is_null(result) && throw(ArgumentError("TreeSitter: no child for field id $field_id"))
+    return result
+end
+
+#
+# Grammar introspection
+#
+
+# Anything carrying a language pointer: the Language itself, or a Tree/Parser to query
+# the grammar they were built with.
+const HasLanguage = Union{Language,Tree,Parser}
+language_ptr(l::Language) = l.ptr
+language_ptr(t::Tree) = API.ts_tree_language(t.ptr)
+language_ptr(p::Parser) = API.ts_parser_language(p.ptr)
+
+symbol_count(x::HasLanguage) = Int(API.ts_language_symbol_count(language_ptr(x)))
+symbol_name(x::HasLanguage, id::Integer) =
+    unsafe_string(API.ts_language_symbol_name(language_ptr(x), id))
+symbol_for_name(x::HasLanguage, name::AbstractString, named::Bool) =
+    Int(API.ts_language_symbol_for_name(language_ptr(x), String(name), sizeof(name), named))
+symbol_type(x::HasLanguage, id::Integer) = API.ts_language_symbol_type(language_ptr(x), id)
+
+field_count(x::HasLanguage) = Int(API.ts_language_field_count(language_ptr(x)))
+field_name_for_id(x::HasLanguage, id::Integer) =
+    unsafe_string(API.ts_language_field_name_for_id(language_ptr(x), id))
+field_id_for_name(x::HasLanguage, name::AbstractString) =
+    Int(API.ts_language_field_id_for_name(language_ptr(x), String(name), sizeof(name)))
+
 #
 # Query
 #
@@ -448,6 +478,15 @@ pattern_count(q::Query) = Int(API.ts_query_pattern_count(q.ptr))
 capture_count(q::Query) = Int(API.ts_query_capture_count(q.ptr))
 string_count(q::Query) = Int(API.ts_query_string_count(q.ptr))
 
+# 1-based byte offset where the given pattern (1-based) starts in the query source.
+start_byte_for_pattern(q::Query, pattern::Integer) =
+    Int(API.ts_query_start_byte_for_pattern(q.ptr, pattern - 1)) + 1
+
+disable_pattern!(q::Query, pattern::Integer) =
+    (API.ts_query_disable_pattern(q.ptr, pattern - 1); q)
+disable_capture!(q::Query, name::AbstractString) =
+    (API.ts_query_disable_capture(q.ptr, String(name), sizeof(name)); q)
+
 mutable struct QueryCursor
     ptr::Ptr{API.TSQueryCursor}
     tree::Union{Tree,Nothing}
@@ -483,6 +522,24 @@ function next_match(cursor::QueryCursor)
     match_ref = Ref{API.TSQueryMatch}()
     success = API.ts_query_cursor_next_match(cursor.ptr, match_ref)
     return success ? QueryMatch(match_ref[], cursor.tree) : nothing
+end
+
+# Restrict subsequent matches to a range. Bytes are 1-based; points are 0-based TSPoint.
+set_byte_range!(c::QueryCursor, from::Integer, to::Integer) =
+    (API.ts_query_cursor_set_byte_range(c.ptr, from - 1, to - 1); c)
+set_point_range!(c::QueryCursor, from::API.TSPoint, to::API.TSPoint) =
+    (API.ts_query_cursor_set_point_range(c.ptr, from, to); c)
+
+remove_match!(c::QueryCursor, id::Integer) =
+    (API.ts_query_cursor_remove_match(c.ptr, id); c)
+
+# Next capture in document order, as a (match, capture-index) pair, or nothing when
+# exhausted. The index is 1-based into the match's captures.
+function next_capture(cursor::QueryCursor)
+    match_ref = Ref{API.TSQueryMatch}()
+    index_ref = Ref{UInt32}()
+    success = API.ts_query_cursor_next_capture(cursor.ptr, match_ref, index_ref)
+    return success ? (QueryMatch(match_ref[], cursor.tree), Int(index_ref[]) + 1) : nothing
 end
 
 struct QueryCapture

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -134,6 +134,9 @@ is_missing(n::Node) = API.ts_node_is_missing(n.ptr)
 is_extra(n::Node) = API.ts_node_is_extra(n.ptr)
 is_leaf(n::Node) = iszero(count_nodes(n))
 
+has_error(n::Node) = API.ts_node_has_error(n.ptr)
+has_changes(n::Node) = API.ts_node_has_changes(n.ptr)
+
 count_nodes(n::Node) = Int(API.ts_node_child_count(n.ptr))
 count_named_nodes(n::Node) = Int(API.ts_node_named_child_count(n.ptr))
 
@@ -183,6 +186,23 @@ prev_named_sibling(n::Node) = Node(API.ts_node_prev_named_sibling(n.ptr), n.tree
 # Position info
 start_point(n::Node) = API.ts_node_start_point(n.ptr)
 end_point(n::Node) = API.ts_node_end_point(n.ptr)
+
+# Smallest node spanning a range. Bytes are 1-based to match `byte_range`; points are
+# the 0-based `TSPoint` values returned by `start_point`/`end_point`.
+descendant_for_byte_range(n::Node, from::Integer, to::Integer) =
+    Node(API.ts_node_descendant_for_byte_range(n.ptr, from - 1, to - 1), n.tree)
+named_descendant_for_byte_range(n::Node, from::Integer, to::Integer) =
+    Node(API.ts_node_named_descendant_for_byte_range(n.ptr, from - 1, to - 1), n.tree)
+descendant_for_point_range(n::Node, from::API.TSPoint, to::API.TSPoint) =
+    Node(API.ts_node_descendant_for_point_range(n.ptr, from, to), n.tree)
+named_descendant_for_point_range(n::Node, from::API.TSPoint, to::API.TSPoint) =
+    Node(API.ts_node_named_descendant_for_point_range(n.ptr, from, to), n.tree)
+
+# First child whose extent reaches the given 1-based byte offset.
+first_child_for_byte(n::Node, byte::Integer) =
+    Node(API.ts_node_first_child_for_byte(n.ptr, byte - 1), n.tree)
+first_named_child_for_byte(n::Node, byte::Integer) =
+    Node(API.ts_node_first_named_child_for_byte(n.ptr, byte - 1), n.tree)
 
 #
 # Query

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -107,6 +107,13 @@ Base.show(io::IO, t::Tree) = show(io, root(t))
 
 root(t::Tree) = Node(API.ts_tree_root_node(t.ptr), t)
 
+Base.copy(t::Tree) = Tree(API.ts_tree_copy(t.ptr))
+
+# Incremental reparse. `old` must have the corresponding `edit!` applied so tree-sitter
+# can reuse the unchanged subtrees.
+Base.parse(p::Parser, text::AbstractString, old::Tree) =
+    Tree(API.ts_parser_parse_string(p.ptr, old.ptr, text, sizeof(text)))
+
 traverse(f, tree::Tree, iter = children) = traverse(f, root(tree), iter)
 
 #
@@ -293,6 +300,47 @@ function traverse(f, c::TreeCursor)
     end
     f(node, field, false)
     return nothing
+end
+
+#
+# Editing
+#
+
+# Describe a source edit. Byte offsets are 1-based to match `byte_range`; points are
+# 0-based TSPoint values, as returned by `start_point`/`end_point`.
+input_edit(
+    start_byte::Integer,
+    old_end_byte::Integer,
+    new_end_byte::Integer,
+    start_point::API.TSPoint,
+    old_end_point::API.TSPoint,
+    new_end_point::API.TSPoint,
+) = API.TSInputEdit(
+    start_byte - 1,
+    old_end_byte - 1,
+    new_end_byte - 1,
+    start_point,
+    old_end_point,
+    new_end_point,
+)
+
+edit!(t::Tree, e::API.TSInputEdit) = (API.ts_tree_edit(t.ptr, Ref(e)); t)
+
+# Apply an edit to a node held outside a tree, returning the adjusted node.
+function edit!(n::Node, e::API.TSInputEdit)
+    ref = Ref(n.ptr)
+    API.ts_node_edit(ref, Ref(e))
+    return Node(ref[], n.tree)
+end
+
+# Ranges that differ between an edited old tree and its incremental reparse. Byte and
+# point fields on each TSRange are 0-based C offsets.
+function changed_ranges(old::Tree, new::Tree)
+    len = Ref{UInt32}()
+    ptr = API.ts_tree_get_changed_ranges(old.ptr, new.ptr, len)
+    ranges = [unsafe_load(ptr, i) for i = 1:Int(len[])]
+    Libc.free(ptr)
+    return ranges
 end
 
 #

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -68,8 +68,9 @@ Base.show(io::IO, l::Language) = print(io, "Language(", repr(l.name), ")")
 mutable struct Parser
     language::Language
     ptr::Ptr{API.TSParser}
+    logger_sink::Union{Function,Nothing}  # keeps a set_logger! callback alive while installed
     function Parser(lang::Language)
-        parser = new(lang, API.ts_parser_new())
+        parser = new(lang, API.ts_parser_new(), nothing)
         finalizer(p -> API.ts_parser_delete(p.ptr), parser)
         set_language!(parser, lang)
         return parser
@@ -88,8 +89,86 @@ function set_language!(parser::Parser, language::Language)
     return parser
 end
 
-Base.parse(p::Parser, text::AbstractString) =
-    Tree(API.ts_parser_parse_string(p.ptr, C_NULL, text, sizeof(text)))
+function Base.parse(p::Parser, text::AbstractString; encoding::Symbol = :utf8)
+    encoding === :utf8 &&
+        return Tree(API.ts_parser_parse_string(p.ptr, C_NULL, text, sizeof(text)))
+    encoding === :utf16 || throw(ArgumentError("unknown encoding $encoding"))
+    units = transcode(UInt16, String(text))
+    GC.@preserve units begin
+        buffer = Cstring(reinterpret(Ptr{Cchar}, pointer(units)))
+        return Tree(
+            API.ts_parser_parse_string_encoding(
+                p.ptr,
+                C_NULL,
+                buffer,
+                UInt32(2 * length(units)),
+                API.TSInputEncodingUTF16,
+            ),
+        )
+    end
+end
+
+reset!(p::Parser) = (API.ts_parser_reset(p.ptr); p)
+
+# Restrict parsing to the given source ranges (byte/point fields are 0-based). Useful for
+# language injection, e.g. parsing only the script regions of an HTML document.
+function set_included_ranges!(p::Parser, ranges::Vector{API.TSRange})
+    ok = GC.@preserve ranges API.ts_parser_set_included_ranges(
+        p.ptr,
+        pointer(ranges),
+        length(ranges),
+    )
+    ok || throw(ArgumentError("TreeSitter: included ranges must be ordered and disjoint"))
+    return p
+end
+
+function included_ranges(p::Parser)
+    len = Ref{UInt32}()
+    ptr = API.ts_parser_included_ranges(p.ptr, len)
+    # The array is owned by the parser; do not free it.
+    return [unsafe_load(ptr, i) for i = 1:Int(len[])]
+end
+
+# C-callable trampoline: payload is the Parser, whose logger_sink field holds the sink.
+function _logger_trampoline(
+    payload::Ptr{Cvoid},
+    log_type::API.TSLogType,
+    buffer::Ptr{Cchar},
+)
+    parser = unsafe_pointer_to_objref(payload)::Parser
+    sink = parser.logger_sink
+    sink === nothing ||
+        sink(log_type === API.TSLogTypeLex ? :lex : :parse, unsafe_string(buffer))
+    return nothing
+end
+
+# Install a logger called as sink(kind::Symbol, message::String) during parsing, where
+# kind is :parse or :lex.
+function set_logger!(p::Parser, sink::Function)
+    p.logger_sink = sink
+    trampoline =
+        @cfunction(_logger_trampoline, Cvoid, (Ptr{Cvoid}, API.TSLogType, Ptr{Cchar}))
+    API.ts_parser_set_logger(p.ptr, API.TSLogger(pointer_from_objref(p), trampoline))
+    return p
+end
+
+logger(p::Parser) = API.ts_parser_logger(p.ptr)
+
+# Write parser DOT graphs during subsequent parses. dest is a file path, an IO, or
+# nothing to disable. tree-sitter owns a duplicate of the file descriptor and flushes it
+# when graphs are disabled or redirected.
+function print_dot_graphs!(p::Parser, io::IO)
+    API.ts_parser_print_dot_graphs(p.ptr, _dup_fd(Base.fd(io)))
+    return p
+end
+
+print_dot_graphs!(p::Parser, path::AbstractString) =
+    open(io -> print_dot_graphs!(p, io), path; write = true)
+
+print_dot_graphs!(p::Parser, ::Nothing) = (API.ts_parser_print_dot_graphs(p.ptr, -1); p)
+
+_dup_fd(fd) = @static Sys.iswindows() ? ccall(:_dup, Cint, (Cint,), fd) :
+        ccall(:dup, Cint, (Cint,), fd)
 
 #
 # Tree

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -89,6 +89,26 @@ function set_language!(parser::Parser, language::Language)
     return parser
 end
 
+"""
+    parse(parser::Parser, text::AbstractString; encoding=:utf8) -> Tree
+    parse(parser::Parser, source::Function; encoding=:utf8) -> Tree
+    parse(parser::Parser, text::AbstractString, old::Tree) -> Tree
+
+Parse source into a `Tree`. `encoding` is `:utf8` or `:utf16`.
+
+Pass a `source` callback to parse a source not held as a single `String`:
+`source(offset)` returns the chunk at a 1-based byte offset, or an empty string at end
+of input.
+
+Pass an `old` tree that has had the matching `edit!` applied to reparse incrementally,
+reusing the unchanged subtrees.
+
+# Example
+```julia
+parser = Parser(tree_sitter_julia_jll)
+tree = parse(parser, "f(x) = x + 1")
+```
+"""
 function Base.parse(p::Parser, text::AbstractString; encoding::Symbol = :utf8)
     encoding === :utf8 &&
         return Tree(API.ts_parser_parse_string(p.ptr, C_NULL, text, sizeof(text)))
@@ -128,8 +148,6 @@ function _input_trampoline(
     return isempty(state.chunk) ? Ptr{Cchar}(C_NULL) : Ptr{Cchar}(pointer(state.chunk))
 end
 
-# Parse from a callback that returns the source chunk at a given 1-based byte offset and
-# an empty string at end of input. Useful for sources not held as a single String.
 function Base.parse(p::Parser, source::Function; encoding::Symbol = :utf8)
     enc =
         encoding === :utf8 ? API.TSInputEncodingUTF8 :
@@ -147,10 +165,21 @@ function Base.parse(p::Parser, source::Function; encoding::Symbol = :utf8)
     end
 end
 
+"""
+    reset!(parser::Parser) -> Parser
+
+Discard the parser's state so the next `parse` starts fresh rather than resuming a
+cancelled parse.
+"""
 reset!(p::Parser) = (API.ts_parser_reset(p.ptr); p)
 
-# Restrict parsing to the given source ranges (byte/point fields are 0-based). Useful for
-# language injection, e.g. parsing only the script regions of an HTML document.
+"""
+    set_included_ranges!(parser::Parser, ranges::Vector{API.TSRange}) -> Parser
+
+Restrict parsing to the given source ranges (byte and point fields are 0-based). Used
+for language injection, such as parsing only the script regions of an HTML document.
+Throws if the ranges are not ordered and disjoint.
+"""
 function set_included_ranges!(p::Parser, ranges::Vector{API.TSRange})
     ok = GC.@preserve ranges API.ts_parser_set_included_ranges(
         p.ptr,
@@ -161,6 +190,12 @@ function set_included_ranges!(p::Parser, ranges::Vector{API.TSRange})
     return p
 end
 
+"""
+    included_ranges(parser::Parser) -> Vector{API.TSRange}
+
+Return the ranges the parser is restricted to. A fresh parser reports a single range
+covering the whole document.
+"""
 function included_ranges(p::Parser)
     len = Ref{UInt32}()
     ptr = API.ts_parser_included_ranges(p.ptr, len)
@@ -181,8 +216,12 @@ function _logger_trampoline(
     return nothing
 end
 
-# Install a logger called as sink(kind::Symbol, message::String) during parsing, where
-# kind is :parse or :lex.
+"""
+    set_logger!(parser::Parser, sink::Function) -> Parser
+
+Install a logging callback invoked as `sink(kind::Symbol, message::String)` during
+parsing, where `kind` is `:parse` or `:lex`.
+"""
 function set_logger!(p::Parser, sink::Function)
     p.logger_sink = sink
     trampoline =
@@ -191,11 +230,21 @@ function set_logger!(p::Parser, sink::Function)
     return p
 end
 
+"""
+    logger(parser::Parser) -> API.TSLogger
+
+Return the parser's current logger. The `log` field is null when none is installed.
+"""
 logger(p::Parser) = API.ts_parser_logger(p.ptr)
 
-# Write parser DOT graphs during subsequent parses. dest is a file path, an IO, or
-# nothing to disable. tree-sitter owns a duplicate of the file descriptor and flushes it
-# when graphs are disabled or redirected.
+"""
+    print_dot_graphs!(parser::Parser, dest) -> Parser
+
+Write parser DOT graphs during subsequent parses. `dest` is a file path, an `IO`, or
+`nothing` to disable. tree-sitter owns a duplicate of the underlying file descriptor and
+flushes it when graphs are disabled or redirected, so call `print_dot_graphs!(parser,
+nothing)` to finish writing.
+"""
 function print_dot_graphs!(p::Parser, io::IO)
     API.ts_parser_print_dot_graphs(p.ptr, _dup_fd(Base.fd(io)))
     return p
@@ -225,10 +274,14 @@ Base.show(io::IO, t::Tree) = show(io, root(t))
 
 root(t::Tree) = Node(API.ts_tree_root_node(t.ptr), t)
 
+"""
+    copy(tree::Tree) -> Tree
+
+Return an independent copy of `tree`, useful for keeping the pre-edit tree when reparsing
+incrementally.
+"""
 Base.copy(t::Tree) = Tree(API.ts_tree_copy(t.ptr))
 
-# Incremental reparse. `old` must have the corresponding `edit!` applied so tree-sitter
-# can reuse the unchanged subtrees.
 Base.parse(p::Parser, text::AbstractString, old::Tree) =
     Tree(API.ts_parser_parse_string(p.ptr, old.ptr, text, sizeof(text)))
 
@@ -259,7 +312,18 @@ is_missing(n::Node) = API.ts_node_is_missing(n.ptr)
 is_extra(n::Node) = API.ts_node_is_extra(n.ptr)
 is_leaf(n::Node) = iszero(count_nodes(n))
 
+"""
+    has_error(n::Node) -> Bool
+
+Return `true` if `n` or any node beneath it is a syntax error.
+"""
 has_error(n::Node) = API.ts_node_has_error(n.ptr)
+
+"""
+    has_changes(n::Node) -> Bool
+
+Return `true` if `n` overlaps a region edited since the last parse.
+"""
 has_changes(n::Node) = API.ts_node_has_changes(n.ptr)
 
 count_nodes(n::Node) = Int(API.ts_node_child_count(n.ptr))
@@ -312,8 +376,16 @@ prev_named_sibling(n::Node) = Node(API.ts_node_prev_named_sibling(n.ptr), n.tree
 start_point(n::Node) = API.ts_node_start_point(n.ptr)
 end_point(n::Node) = API.ts_node_end_point(n.ptr)
 
-# Smallest node spanning a range. Bytes are 1-based to match `byte_range`; points are
-# the 0-based `TSPoint` values returned by `start_point`/`end_point`.
+"""
+    descendant_for_byte_range(n::Node, from, to) -> Node
+    named_descendant_for_byte_range(n::Node, from, to) -> Node
+    descendant_for_point_range(n::Node, from::API.TSPoint, to::API.TSPoint) -> Node
+    named_descendant_for_point_range(n::Node, from::API.TSPoint, to::API.TSPoint) -> Node
+
+Return the smallest node under `n` that spans the given range. Byte offsets are 1-based,
+matching `byte_range`; points are the 0-based `TSPoint` values returned by `start_point`
+and `end_point`. The `named_` variants skip anonymous nodes.
+"""
 descendant_for_byte_range(n::Node, from::Integer, to::Integer) =
     Node(API.ts_node_descendant_for_byte_range(n.ptr, from - 1, to - 1), n.tree)
 named_descendant_for_byte_range(n::Node, from::Integer, to::Integer) =
@@ -323,12 +395,24 @@ descendant_for_point_range(n::Node, from::API.TSPoint, to::API.TSPoint) =
 named_descendant_for_point_range(n::Node, from::API.TSPoint, to::API.TSPoint) =
     Node(API.ts_node_named_descendant_for_point_range(n.ptr, from, to), n.tree)
 
-# First child whose extent reaches the given 1-based byte offset.
+"""
+    first_child_for_byte(n::Node, byte) -> Node
+    first_named_child_for_byte(n::Node, byte) -> Node
+
+Return the first child of `n` whose extent reaches the given 1-based byte offset. The
+`named_` variant skips anonymous nodes.
+"""
 first_child_for_byte(n::Node, byte::Integer) =
     Node(API.ts_node_first_child_for_byte(n.ptr, byte - 1), n.tree)
 first_named_child_for_byte(n::Node, byte::Integer) =
     Node(API.ts_node_first_named_child_for_byte(n.ptr, byte - 1), n.tree)
 
+"""
+    child_by_field_id(n::Node, field_id::Integer) -> Node
+
+Return the child of `n` for the numeric `field_id`. Throws if there is no such child.
+Use `field_id_for_name` to resolve a field name to an id.
+"""
 function child_by_field_id(n::Node, field_id::Integer)
     result = Node(API.ts_node_child_by_field_id(n.ptr, field_id), n.tree)
     is_null(result) && throw(ArgumentError("TreeSitter: no child for field id $field_id"))
@@ -346,16 +430,57 @@ language_ptr(l::Language) = l.ptr
 language_ptr(t::Tree) = API.ts_tree_language(t.ptr)
 language_ptr(p::Parser) = API.ts_parser_language(p.ptr)
 
+"""
+    symbol_count(x) -> Int
+
+Number of distinct node types in the grammar. `x` is a `Language`, `Tree`, or `Parser`.
+"""
 symbol_count(x::HasLanguage) = Int(API.ts_language_symbol_count(language_ptr(x)))
+
+"""
+    symbol_name(x, id::Integer) -> String
+
+Name of the node type with the given symbol id.
+"""
 symbol_name(x::HasLanguage, id::Integer) =
     unsafe_string(API.ts_language_symbol_name(language_ptr(x), id))
+
+"""
+    symbol_for_name(x, name::AbstractString, named::Bool) -> Int
+
+Symbol id for a node type. `named` selects a named node type over an anonymous one of
+the same name.
+"""
 symbol_for_name(x::HasLanguage, name::AbstractString, named::Bool) =
     Int(API.ts_language_symbol_for_name(language_ptr(x), String(name), sizeof(name), named))
+
+"""
+    symbol_type(x, id::Integer) -> API.TSSymbolType
+
+Whether the symbol id is a regular, anonymous, or auxiliary node type.
+"""
 symbol_type(x::HasLanguage, id::Integer) = API.ts_language_symbol_type(language_ptr(x), id)
 
+"""
+    field_count(x) -> Int
+
+Number of distinct field names in the grammar.
+"""
 field_count(x::HasLanguage) = Int(API.ts_language_field_count(language_ptr(x)))
+
+"""
+    field_name_for_id(x, id::Integer) -> String
+
+Field name for the given field id.
+"""
 field_name_for_id(x::HasLanguage, id::Integer) =
     unsafe_string(API.ts_language_field_name_for_id(language_ptr(x), id))
+
+"""
+    field_id_for_name(x, name::AbstractString) -> Int
+
+Field id for the given field name.
+"""
 field_id_for_name(x::HasLanguage, name::AbstractString) =
     Int(API.ts_language_field_id_for_name(language_ptr(x), String(name), sizeof(name)))
 
@@ -363,8 +488,15 @@ field_id_for_name(x::HasLanguage, name::AbstractString) =
 # TreeCursor
 #
 
-# Stateful walk over a tree. Cheaper than repeated Node navigation for full traversals,
-# and exposes the field name a node occupies in its parent.
+"""
+    TreeCursor(n::Node)
+    TreeCursor(t::Tree)
+
+A stateful cursor over a tree. Cheaper than repeated `Node` navigation for full
+traversals, and exposes the field name a node occupies in its parent. Move it with the
+`goto_*` methods and read its position with `current_node`, `current_field_name`, and
+`current_field_id`.
+"""
 mutable struct TreeCursor
     ref::Base.RefValue{API.TSTreeCursor}
     tree::Tree
@@ -378,34 +510,76 @@ TreeCursor(n::Node) = TreeCursor(Ref(API.ts_tree_cursor_new(n.ptr)), n.tree)
 TreeCursor(t::Tree) = TreeCursor(root(t))
 Base.show(io::IO, ::TreeCursor) = print(io, "TreeCursor()")
 
+"""
+    current_node(c::TreeCursor) -> Node
+
+The node the cursor is currently on.
+"""
 current_node(c::TreeCursor) = Node(API.ts_tree_cursor_current_node(c.ref), c.tree)
+
+"""
+    current_field_id(c::TreeCursor) -> Int
+
+Field id the current node occupies in its parent, or `0` for none.
+"""
 current_field_id(c::TreeCursor) = Int(API.ts_tree_cursor_current_field_id(c.ref))
 
-# Field name the current node occupies in its parent, or nothing at the root or for
-# children with no field.
+"""
+    current_field_name(c::TreeCursor) -> Union{String,Nothing}
+
+Field name the current node occupies in its parent, or `nothing` at the root and for
+children with no field.
+"""
 function current_field_name(c::TreeCursor)
     str = API.ts_tree_cursor_current_field_name(c.ref)
     return reinterpret(Ptr{Cchar}, str) == C_NULL ? nothing : unsafe_string(str)
 end
 
+"""
+    goto_parent!(c::TreeCursor) -> Bool
+    goto_next_sibling!(c::TreeCursor) -> Bool
+    goto_first_child!(c::TreeCursor) -> Bool
+
+Move the cursor to the parent, next sibling, or first child. Return `false` and leave the
+cursor in place when there is no such node.
+"""
 goto_parent!(c::TreeCursor) = API.ts_tree_cursor_goto_parent(c.ref) != 0
 goto_next_sibling!(c::TreeCursor) = API.ts_tree_cursor_goto_next_sibling(c.ref) != 0
 goto_first_child!(c::TreeCursor) = API.ts_tree_cursor_goto_first_child(c.ref) != 0
 
-# Move to the first child reaching the given 1-based byte offset; returns its 1-based
-# index, or nothing if there is none.
+"""
+    goto_first_child_for_byte!(c::TreeCursor, byte) -> Union{Int,Nothing}
+
+Move to the first child reaching the given 1-based byte offset, returning its 1-based
+index, or `nothing` if there is none.
+"""
 function goto_first_child_for_byte!(c::TreeCursor, byte::Integer)
     index = API.ts_tree_cursor_goto_first_child_for_byte(c.ref, byte - 1)
     return index < 0 ? nothing : Int(index) + 1
 end
 
+"""
+    reset!(c::TreeCursor, n::Node) -> TreeCursor
+
+Move the cursor to `n`, discarding its position.
+"""
 reset!(c::TreeCursor, n::Node) =
     (API.ts_tree_cursor_reset(c.ref, n.ptr); c.tree = n.tree; c)
 
+"""
+    copy(c::TreeCursor) -> TreeCursor
+
+An independent cursor at the same position as `c`.
+"""
 Base.copy(c::TreeCursor) = TreeCursor(Ref(API.ts_tree_cursor_copy(c.ref)), c.tree)
 
-# Depth-first walk via a cursor, calling f(node, field_name, enter) on the way down
-# (enter=true) and up (enter=false). field_name is nothing when the node has no field.
+"""
+    traverse(f, c::TreeCursor)
+
+Walk the subtree under the cursor depth-first, calling `f(node, field_name, enter)` on
+the way down (`enter=true`) and up (`enter=false`). `field_name` is `nothing` when the
+node occupies no field.
+"""
 function traverse(f, c::TreeCursor)
     node, field = current_node(c), current_field_name(c)
     f(node, field, true)
@@ -424,8 +598,13 @@ end
 # Editing
 #
 
-# Describe a source edit. Byte offsets are 1-based to match `byte_range`; points are
-# 0-based TSPoint values, as returned by `start_point`/`end_point`.
+"""
+    input_edit(start_byte, old_end_byte, new_end_byte,
+               start_point, old_end_point, new_end_point) -> API.TSInputEdit
+
+Describe a source edit for `edit!`. Byte offsets are 1-based, matching `byte_range`;
+points are 0-based `TSPoint` values, as returned by `start_point` and `end_point`.
+"""
 input_edit(
     start_byte::Integer,
     old_end_byte::Integer,
@@ -442,17 +621,28 @@ input_edit(
     new_end_point,
 )
 
+"""
+    edit!(tree::Tree, e::API.TSInputEdit) -> Tree
+    edit!(n::Node, e::API.TSInputEdit) -> Node
+
+Apply an edit so the tree can be reparsed incrementally. Edit the tree, then call
+`parse(parser, new_text, tree)`. The `Node` form adjusts a node held outside a tree and
+returns the updated node. Build `e` with `input_edit`.
+"""
 edit!(t::Tree, e::API.TSInputEdit) = (API.ts_tree_edit(t.ptr, Ref(e)); t)
 
-# Apply an edit to a node held outside a tree, returning the adjusted node.
 function edit!(n::Node, e::API.TSInputEdit)
     ref = Ref(n.ptr)
     API.ts_node_edit(ref, Ref(e))
     return Node(ref[], n.tree)
 end
 
-# Ranges that differ between an edited old tree and its incremental reparse. Byte and
-# point fields on each TSRange are 0-based C offsets.
+"""
+    changed_ranges(old::Tree, new::Tree) -> Vector{API.TSRange}
+
+Ranges that differ between an edited `old` tree and its incremental reparse `new`. Byte
+and point fields on each `TSRange` are 0-based.
+"""
 function changed_ranges(old::Tree, new::Tree)
     len = Ref{UInt32}()
     ptr = API.ts_tree_get_changed_ranges(old.ptr, new.ptr, len)
@@ -705,12 +895,27 @@ pattern_count(q::Query) = Int(API.ts_query_pattern_count(q.ptr))
 capture_count(q::Query) = Int(API.ts_query_capture_count(q.ptr))
 string_count(q::Query) = Int(API.ts_query_string_count(q.ptr))
 
-# 1-based byte offset where the given pattern (1-based) starts in the query source.
+"""
+    start_byte_for_pattern(q::Query, pattern::Integer) -> Int
+
+1-based byte offset where the 1-based `pattern` starts in the query source.
+"""
 start_byte_for_pattern(q::Query, pattern::Integer) =
     Int(API.ts_query_start_byte_for_pattern(q.ptr, pattern - 1)) + 1
 
+"""
+    disable_pattern!(q::Query, pattern::Integer) -> Query
+
+Disable the 1-based `pattern` so it produces no matches. Irreversible.
+"""
 disable_pattern!(q::Query, pattern::Integer) =
     (API.ts_query_disable_pattern(q.ptr, pattern - 1); q)
+
+"""
+    disable_capture!(q::Query, name::AbstractString) -> Query
+
+Disable a capture by name so it is dropped from results. Irreversible.
+"""
 disable_capture!(q::Query, name::AbstractString) =
     (API.ts_query_disable_capture(q.ptr, String(name), sizeof(name)); q)
 
@@ -751,17 +956,32 @@ function next_match(cursor::QueryCursor)
     return success ? QueryMatch(match_ref[], cursor.tree) : nothing
 end
 
-# Restrict subsequent matches to a range. Bytes are 1-based; points are 0-based TSPoint.
+"""
+    set_byte_range!(c::QueryCursor, from, to) -> QueryCursor
+    set_point_range!(c::QueryCursor, from::API.TSPoint, to::API.TSPoint) -> QueryCursor
+
+Restrict the cursor's matches to a range. Call before `exec`. Byte offsets are 1-based;
+points are 0-based `TSPoint` values.
+"""
 set_byte_range!(c::QueryCursor, from::Integer, to::Integer) =
     (API.ts_query_cursor_set_byte_range(c.ptr, from - 1, to - 1); c)
 set_point_range!(c::QueryCursor, from::API.TSPoint, to::API.TSPoint) =
     (API.ts_query_cursor_set_point_range(c.ptr, from, to); c)
 
+"""
+    remove_match!(c::QueryCursor, id::Integer) -> QueryCursor
+
+Drop the match with the given id so the cursor will not return it.
+"""
 remove_match!(c::QueryCursor, id::Integer) =
     (API.ts_query_cursor_remove_match(c.ptr, id); c)
 
-# Next capture in document order, as a (match, capture-index) pair, or nothing when
-# exhausted. The index is 1-based into the match's captures.
+"""
+    next_capture(c::QueryCursor) -> Union{Tuple{QueryMatch,Int},Nothing}
+
+The next capture in document order as a `(match, index)` pair where `index` is 1-based
+into the match's captures, or `nothing` when exhausted. Requires a prior `exec`.
+"""
 function next_capture(cursor::QueryCursor)
     match_ref = Ref{API.TSQueryMatch}()
     index_ref = Ref{UInt32}()

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -235,6 +235,67 @@ field_id_for_name(x::HasLanguage, name::AbstractString) =
     Int(API.ts_language_field_id_for_name(language_ptr(x), String(name), sizeof(name)))
 
 #
+# TreeCursor
+#
+
+# Stateful walk over a tree. Cheaper than repeated Node navigation for full traversals,
+# and exposes the field name a node occupies in its parent.
+mutable struct TreeCursor
+    ref::Base.RefValue{API.TSTreeCursor}
+    tree::Tree
+    function TreeCursor(ref::Base.RefValue{API.TSTreeCursor}, tree::Tree)
+        cursor = new(ref, tree)
+        finalizer(c -> API.ts_tree_cursor_delete(c.ref), cursor)
+        return cursor
+    end
+end
+TreeCursor(n::Node) = TreeCursor(Ref(API.ts_tree_cursor_new(n.ptr)), n.tree)
+TreeCursor(t::Tree) = TreeCursor(root(t))
+Base.show(io::IO, ::TreeCursor) = print(io, "TreeCursor()")
+
+current_node(c::TreeCursor) = Node(API.ts_tree_cursor_current_node(c.ref), c.tree)
+current_field_id(c::TreeCursor) = Int(API.ts_tree_cursor_current_field_id(c.ref))
+
+# Field name the current node occupies in its parent, or nothing at the root or for
+# children with no field.
+function current_field_name(c::TreeCursor)
+    str = API.ts_tree_cursor_current_field_name(c.ref)
+    return reinterpret(Ptr{Cchar}, str) == C_NULL ? nothing : unsafe_string(str)
+end
+
+goto_parent!(c::TreeCursor) = API.ts_tree_cursor_goto_parent(c.ref) != 0
+goto_next_sibling!(c::TreeCursor) = API.ts_tree_cursor_goto_next_sibling(c.ref) != 0
+goto_first_child!(c::TreeCursor) = API.ts_tree_cursor_goto_first_child(c.ref) != 0
+
+# Move to the first child reaching the given 1-based byte offset; returns its 1-based
+# index, or nothing if there is none.
+function goto_first_child_for_byte!(c::TreeCursor, byte::Integer)
+    index = API.ts_tree_cursor_goto_first_child_for_byte(c.ref, byte - 1)
+    return index < 0 ? nothing : Int(index) + 1
+end
+
+reset!(c::TreeCursor, n::Node) =
+    (API.ts_tree_cursor_reset(c.ref, n.ptr); c.tree = n.tree; c)
+
+Base.copy(c::TreeCursor) = TreeCursor(Ref(API.ts_tree_cursor_copy(c.ref)), c.tree)
+
+# Depth-first walk via a cursor, calling f(node, field_name, enter) on the way down
+# (enter=true) and up (enter=false). field_name is nothing when the node has no field.
+function traverse(f, c::TreeCursor)
+    node, field = current_node(c), current_field_name(c)
+    f(node, field, true)
+    if goto_first_child!(c)
+        traverse(f, c)
+        while goto_next_sibling!(c)
+            traverse(f, c)
+        end
+        goto_parent!(c)
+    end
+    f(node, field, false)
+    return nothing
+end
+
+#
 # Query
 #
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -108,6 +108,45 @@ function Base.parse(p::Parser, text::AbstractString; encoding::Symbol = :utf8)
     end
 end
 
+# Holds the user's chunk producer and the current chunk, kept alive across read calls.
+mutable struct InputState
+    source::Function
+    chunk::Vector{UInt8}
+end
+
+# C-callable read callback: returns the source chunk starting at a 1-based byte index,
+# or signals EOF with a zero length.
+function _input_trampoline(
+    payload::Ptr{Cvoid},
+    byte_index::UInt32,
+    ::API.TSPoint,
+    bytes_read::Ptr{UInt32},
+)
+    state = unsafe_pointer_to_objref(payload)::InputState
+    state.chunk = Vector{UInt8}(codeunits(String(state.source(Int(byte_index) + 1))))
+    unsafe_store!(bytes_read, UInt32(length(state.chunk)))
+    return isempty(state.chunk) ? Ptr{Cchar}(C_NULL) : Ptr{Cchar}(pointer(state.chunk))
+end
+
+# Parse from a callback that returns the source chunk at a given 1-based byte offset and
+# an empty string at end of input. Useful for sources not held as a single String.
+function Base.parse(p::Parser, source::Function; encoding::Symbol = :utf8)
+    enc =
+        encoding === :utf8 ? API.TSInputEncodingUTF8 :
+        encoding === :utf16 ? API.TSInputEncodingUTF16 :
+        throw(ArgumentError("unknown encoding $encoding"))
+    state = InputState(source, UInt8[])
+    trampoline = @cfunction(
+        _input_trampoline,
+        Ptr{Cchar},
+        (Ptr{Cvoid}, UInt32, API.TSPoint, Ptr{UInt32})
+    )
+    GC.@preserve state begin
+        input = API.TSInput(pointer_from_objref(state), trampoline, enc, C_NULL)
+        return Tree(API.ts_parser_parse(p.ptr, C_NULL, input))
+    end
+end
+
 reset!(p::Parser) = (API.ts_parser_reset(p.ptr); p)
 
 # Restrict parsing to the given source ranges (byte/point fields are 0-based). Useful for

--- a/test/cursor.jl
+++ b/test/cursor.jl
@@ -1,0 +1,66 @@
+import tree_sitter_c_jll
+
+@testset "TreeCursor" begin
+    p = Parser(tree_sitter_c_jll)
+    tree = parse(p, "int main(void){return 0;}")
+
+    @testset "cursor traversal exposes field names" begin
+        visited = Tuple{String,Union{String,Nothing}}[]
+        TreeSitter.traverse(TreeSitter.TreeCursor(tree)) do node, field, enter
+            enter && push!(visited, (TreeSitter.node_type(node), field))
+        end
+
+        types = first.(visited)
+        @test types[1] == "translation_unit"
+        @test "function_definition" in types
+        # The field name a node occupies in its parent surfaces during the walk.
+        @test ("primitive_type", "type") in visited
+        @test ("function_declarator", "declarator") in visited
+        # The root has no field.
+        @test visited[1][2] === nothing
+    end
+
+    @testset "manual navigation" begin
+        cursor = TreeSitter.TreeCursor(tree)
+        @test TreeSitter.node_type(TreeSitter.current_node(cursor)) == "translation_unit"
+        @test TreeSitter.current_field_name(cursor) === nothing
+
+        @test TreeSitter.goto_first_child!(cursor)
+        @test TreeSitter.node_type(TreeSitter.current_node(cursor)) == "function_definition"
+
+        @test TreeSitter.goto_first_child!(cursor)
+        @test TreeSitter.node_type(TreeSitter.current_node(cursor)) == "primitive_type"
+        @test TreeSitter.current_field_name(cursor) == "type"
+        @test TreeSitter.current_field_id(cursor) == TreeSitter.field_id_for_name(p, "type")
+
+        @test TreeSitter.goto_next_sibling!(cursor)
+        @test TreeSitter.node_type(TreeSitter.current_node(cursor)) == "function_declarator"
+
+        @test TreeSitter.goto_parent!(cursor)
+        @test TreeSitter.node_type(TreeSitter.current_node(cursor)) == "function_definition"
+    end
+
+    @testset "copy is independent" begin
+        cursor = TreeSitter.TreeCursor(tree)
+        TreeSitter.goto_first_child!(cursor)  # function_definition
+        clone = copy(cursor)
+        TreeSitter.goto_first_child!(clone)  # primitive_type
+        @test TreeSitter.node_type(TreeSitter.current_node(cursor)) == "function_definition"
+        @test TreeSitter.node_type(TreeSitter.current_node(clone)) == "primitive_type"
+    end
+
+    @testset "reset and goto_first_child_for_byte" begin
+        cursor = TreeSitter.TreeCursor(tree)
+        TreeSitter.goto_first_child!(cursor)
+        @test TreeSitter.node_type(TreeSitter.current_node(cursor)) == "function_definition"
+
+        TreeSitter.reset!(cursor, TreeSitter.root(tree))
+        @test TreeSitter.node_type(TreeSitter.current_node(cursor)) == "translation_unit"
+
+        TreeSitter.goto_first_child!(cursor)
+        @test TreeSitter.goto_first_child_for_byte!(cursor, 1) == 1
+        @test TreeSitter.goto_first_child_for_byte!(cursor, 1000) === nothing
+    end
+
+    @test repr(TreeSitter.TreeCursor(tree)) == "TreeCursor()"
+end

--- a/test/editing.jl
+++ b/test/editing.jl
@@ -1,0 +1,48 @@
+import tree_sitter_c_jll
+
+@testset "Incremental editing" begin
+    p = Parser(tree_sitter_c_jll)
+    src1 = "int x = 1;"
+    src2 = "int x = 1+1;"
+    tree = parse(p, src1)
+
+    @testset "tree copy" begin
+        clone = copy(tree)
+        @test clone !== tree
+        @test TreeSitter.node_type(TreeSitter.root(clone)) == "translation_unit"
+    end
+
+    # Insert "+1" after the literal "1", turning it into a binary expression. The edit
+    # starts at 1-based byte 10 (0-based column 9) and adds two characters.
+    e = TreeSitter.input_edit(
+        10,
+        10,
+        12,
+        TreeSitter.API.TSPoint(0, 9),
+        TreeSitter.API.TSPoint(0, 9),
+        TreeSitter.API.TSPoint(0, 11),
+    )
+    TreeSitter.edit!(tree, e)
+    new_tree = parse(p, src2, tree)
+
+    @testset "reparse reflects the structural change" begin
+        node = TreeSitter.descendant_for_byte_range(TreeSitter.root(new_tree), 9, 11)
+        @test TreeSitter.node_type(node) == "binary_expression"
+        @test TreeSitter.slice(src2, node) == "1+1"
+    end
+
+    @testset "changed_ranges reports the edited span" begin
+        ranges = TreeSitter.changed_ranges(tree, new_tree)
+        @test length(ranges) == 1
+        # The new binary expression spans 0-based bytes 8..11.
+        r = only(ranges)
+        @test r.start_byte <= 8
+        @test r.end_byte >= 11
+    end
+
+    @testset "node edit returns the adjusted node" begin
+        fresh = parse(p, src1)
+        adjusted = TreeSitter.edit!(TreeSitter.root(fresh), e)
+        @test TreeSitter.node_type(adjusted) == "translation_unit"
+    end
+end

--- a/test/introspection.jl
+++ b/test/introspection.jl
@@ -1,4 +1,9 @@
-import tree_sitter_c_jll
+import tree_sitter_c_jll, tree_sitter_php_jll
+
+@testset "Parser variant errors" begin
+    # A JLL exposes a fixed set of parser variants; an unknown one is an error.
+    @test_throws ErrorException Language(tree_sitter_php_jll, :nonexistent_variant)
+end
 
 @testset "Grammar introspection" begin
     p = Parser(tree_sitter_c_jll)

--- a/test/introspection.jl
+++ b/test/introspection.jl
@@ -1,0 +1,93 @@
+import tree_sitter_c_jll
+
+@testset "Grammar introspection" begin
+    p = Parser(tree_sitter_c_jll)
+
+    @test TreeSitter.symbol_count(p) > 0
+    id_sym = TreeSitter.symbol_for_name(p, "identifier", true)
+    @test id_sym > 0
+    @test TreeSitter.symbol_name(p, id_sym) == "identifier"
+    @test TreeSitter.symbol_type(p, id_sym) == TreeSitter.API.TSSymbolTypeRegular
+
+    @test TreeSitter.field_count(p) > 0
+    fid = TreeSitter.field_id_for_name(p, "type")
+    @test fid > 0
+    @test TreeSitter.field_name_for_id(p, fid) == "type"
+
+    tree = parse(p, "int main(void){return 0;}")
+    # Introspection resolves the grammar from a Language, Tree, or Parser.
+    @test TreeSitter.symbol_count(tree) == TreeSitter.symbol_count(p)
+    @test TreeSitter.symbol_count(p.language) == TreeSitter.symbol_count(p)
+
+    func_def = TreeSitter.child(TreeSitter.root(tree), 1)
+    type_node = TreeSitter.child_by_field_id(func_def, fid)
+    @test TreeSitter.node_type(type_node) == "primitive_type"
+    @test_throws ArgumentError TreeSitter.child_by_field_id(func_def, 9999)
+end
+
+@testset "Query scoping" begin
+    p = Parser(tree_sitter_c_jll)
+    src = "int x; int y;"
+    tree = parse(p, src)
+    q = Query(tree_sitter_c_jll, "(identifier) @id")
+
+    @test TreeSitter.start_byte_for_pattern(q, 1) == 1
+
+    capture_text(cursor) =
+        [TreeSitter.slice(src, c.node) for m in cursor for c in TreeSitter.captures(m)]
+
+    # Byte range restricts matches to the first declaration "int x;".
+    by_byte = TreeSitter.QueryCursor()
+    TreeSitter.set_byte_range!(by_byte, 1, 7)
+    TreeSitter.exec(by_byte, q, tree)
+    @test capture_text(by_byte) == ["x"]
+
+    # Point range (0-based TSPoint) restricts the same way.
+    by_point = TreeSitter.QueryCursor()
+    TreeSitter.set_point_range!(
+        by_point,
+        TreeSitter.API.TSPoint(0, 0),
+        TreeSitter.API.TSPoint(0, 6),
+    )
+    TreeSitter.exec(by_point, q, tree)
+    @test capture_text(by_point) == ["x"]
+
+    # next_capture walks captures in document order.
+    walk = TreeSitter.QueryCursor()
+    TreeSitter.exec(walk, q, tree)
+    order = String[]
+    while (nc = TreeSitter.next_capture(walk)) !== nothing
+        match, idx = nc
+        capture = first(Iterators.drop(TreeSitter.captures(match), idx - 1))
+        push!(order, TreeSitter.slice(src, capture.node))
+    end
+    @test order == ["x", "y"]
+
+    # remove_match! returns the cursor; exercises the removal binding.
+    removable = TreeSitter.QueryCursor()
+    TreeSitter.exec(removable, q, tree)
+    @test TreeSitter.remove_match!(removable, 0) === removable
+end
+
+@testset "Disabling patterns and captures" begin
+    p = Parser(tree_sitter_c_jll)
+    src = "int x; int y;"
+    tree = parse(p, src)
+
+    # Disabling the only capture drops it from results.
+    q_cap = Query(tree_sitter_c_jll, "(identifier) @id")
+    TreeSitter.disable_capture!(q_cap, "id")
+    cursor = TreeSitter.QueryCursor()
+    TreeSitter.exec(cursor, q_cap, tree)
+    @test isempty([c for m in cursor for c in TreeSitter.captures(m)])
+
+    # Disabling a pattern removes its matches, leaving the other pattern.
+    q_pat = Query(tree_sitter_c_jll, "(identifier) @a\n(primitive_type) @b")
+    TreeSitter.disable_pattern!(q_pat, 1)
+    cursor2 = TreeSitter.QueryCursor()
+    TreeSitter.exec(cursor2, q_pat, tree)
+    names =
+        [TreeSitter.capture_name(q_pat, c) for m in cursor2 for c in TreeSitter.captures(m)]
+    @test all(==("b"), names)
+    @test !isempty(names)
+end

--- a/test/nodes.jl
+++ b/test/nodes.jl
@@ -211,6 +211,45 @@ end
     @test TreeSitter.slice("[1, 2, 3]", prev_named) == "2"
 end
 
+@testset "Node Health" begin
+    p = Parser(tree_sitter_c_jll)
+
+    valid = TreeSitter.root(parse(p, "int x = 1;"))
+    @test !TreeSitter.has_error(valid)
+    @test !TreeSitter.has_changes(valid)
+
+    # Missing semicolon produces an ERROR/MISSING node.
+    broken = TreeSitter.root(parse(p, "int x"))
+    @test TreeSitter.has_error(broken)
+end
+
+@testset "Descendant Lookup" begin
+    p = Parser(tree_sitter_c_jll)
+    src = "int x = 1;"
+    root_node = TreeSitter.root(parse(p, src))
+
+    # Byte offsets are 1-based, matching `byte_range`/`slice`.
+    ident = TreeSitter.descendant_for_byte_range(root_node, 5, 5)
+    @test TreeSitter.node_type(ident) == "identifier"
+    @test TreeSitter.slice(src, ident) == "x"
+
+    num = TreeSitter.named_descendant_for_byte_range(root_node, 9, 9)
+    @test TreeSitter.node_type(num) == "number_literal"
+
+    # Point ranges round-trip through start_point/end_point (0-based TSPoint).
+    from, to = TreeSitter.start_point(ident), TreeSitter.end_point(ident)
+    by_point = TreeSitter.descendant_for_point_range(root_node, from, to)
+    @test by_point == ident
+    @test TreeSitter.node_type(
+        TreeSitter.named_descendant_for_point_range(root_node, from, to),
+    ) == "identifier"
+
+    @test TreeSitter.node_type(TreeSitter.first_child_for_byte(root_node, 1)) ==
+          "declaration"
+    @test TreeSitter.node_type(TreeSitter.first_named_child_for_byte(root_node, 1)) ==
+          "declaration"
+end
+
 @testset "TSPoint Positions" begin
     p = Parser(tree_sitter_julia_jll)
     source = "f(x) = x + 1"

--- a/test/parser_control.jl
+++ b/test/parser_control.jl
@@ -1,0 +1,65 @@
+import tree_sitter_c_jll
+
+@testset "Parser control" begin
+    p = Parser(tree_sitter_c_jll)
+
+    @testset "reset" begin
+        @test TreeSitter.reset!(p) === p
+    end
+
+    @testset "UTF-16 parsing" begin
+        tree = parse(p, "int x = 1;"; encoding = :utf16)
+        @test TreeSitter.node_type(TreeSitter.root(tree)) == "translation_unit"
+        @test !TreeSitter.has_error(TreeSitter.root(tree))
+        @test_throws ArgumentError parse(p, "x"; encoding = :latin1)
+    end
+
+    @testset "included ranges" begin
+        # A fresh parser reports one range covering the whole document.
+        @test length(TreeSitter.included_ranges(p)) == 1
+
+        r = TreeSitter.API.TSRange(
+            TreeSitter.API.TSPoint(0, 0),
+            TreeSitter.API.TSPoint(0, 6),
+            0,
+            6,
+        )
+        TreeSitter.set_included_ranges!(p, [r])
+        got = TreeSitter.included_ranges(p)
+        @test length(got) == 1
+        @test got[1].end_byte == 6
+
+        # An empty range list restores the whole document.
+        TreeSitter.set_included_ranges!(p, TreeSitter.API.TSRange[])
+        @test length(TreeSitter.included_ranges(p)) == 1
+    end
+
+    @testset "logger" begin
+        logs = Tuple{Symbol,String}[]
+        TreeSitter.set_logger!(p, (kind, msg) -> push!(logs, (kind, msg)))
+        parse(p, "int y;")
+        @test !isempty(logs)
+        @test all(t -> t[1] in (:parse, :lex), logs)
+        @test TreeSitter.logger(p).log != C_NULL
+    end
+
+    @testset "dot graphs" begin
+        @testset "io" begin
+            mktemp() do path, io
+                TreeSitter.print_dot_graphs!(p, io)
+                parse(p, "int z;")
+                TreeSitter.print_dot_graphs!(p, nothing)
+                @test filesize(path) > 0
+            end
+        end
+        @testset "path" begin
+            mktemp() do path, io
+                close(io)
+                TreeSitter.print_dot_graphs!(p, path)
+                parse(p, "int z;")
+                TreeSitter.print_dot_graphs!(p, nothing)
+                @test filesize(path) > 0
+            end
+        end
+    end
+end

--- a/test/parser_control.jl
+++ b/test/parser_control.jl
@@ -63,3 +63,16 @@ import tree_sitter_c_jll
         end
     end
 end
+
+@testset "Streaming input parsing" begin
+    parser = Parser(tree_sitter_c_jll)
+    src = "int x = 1;"
+    # The callback returns the source from a 1-based byte offset, or "" at end of input.
+    tree = parse(parser, i -> i <= sizeof(src) ? src[i:end] : "")
+    @test TreeSitter.node_type(TreeSitter.root(tree)) == "translation_unit"
+    @test !TreeSitter.has_error(TreeSitter.root(tree))
+    # Produces the same tree as parsing the whole string.
+    @test TreeSitter.node_string(TreeSitter.root(tree)) ==
+          TreeSitter.node_string(TreeSitter.root(parse(parser, src)))
+    @test_throws ArgumentError parse(parser, i -> ""; encoding = :latin1)
+end

--- a/test/predicates.jl
+++ b/test/predicates.jl
@@ -1,0 +1,159 @@
+import tree_sitter_c_jll, tree_sitter_julia_jll
+
+# Collect the text of every capture a query yields, evaluating all predicates.
+function predicate_captures(jll, src, qsrc)
+    p = Parser(jll)
+    tree = parse(p, src)
+    q = Query(jll, qsrc)
+    return collect(
+        TreeSitter.slice(src, c.node) for c in TreeSitter.each_capture(tree, q, src)
+    )
+end
+
+@testset "Predicate edge cases" begin
+    # tree-sitter 0.25 does not validate predicate arity at query construction, so
+    # malformed predicates reach the match-time warning branches in predicate().
+    @testset "wrong arity warns and filters: $name" for (name, qsrc, rx) in [
+        ("eq?", "((identifier) @x (#eq? @x))", r"'eq\?'"),
+        ("not-eq?", "((identifier) @x (#not-eq? @x))", r"'not-eq\?'"),
+        ("any-of?", "((identifier) @x (#any-of? @x))", r"'any-of\?'"),
+        ("has-ancestor?", "((identifier) @x (#has-ancestor? @x))", r"'has-ancestor\?'"),
+        ("match?", "((identifier) @x (#match? @x))", r"'match\?'"),
+        ("not-match?", "((identifier) @x (#not-match? @x))", r"'not-match\?'"),
+        ("any-eq?", "((identifier) @x (#any-eq? @x))", r"'any-eq\?'"),
+        ("any-not-eq?", "((identifier) @x (#any-not-eq? @x))", r"'any-not-eq\?'"),
+        ("any-match?", "((identifier) @x (#any-match? @x))", r"'any-match\?'"),
+        ("any-not-match?", "((identifier) @x (#any-not-match? @x))", r"'any-not-match\?'"),
+    ]
+        result = @test_logs (:warn, rx) match_mode = :any predicate_captures(
+            tree_sitter_c_jll,
+            "int x;",
+            qsrc,
+        )
+        @test isempty(result)
+    end
+
+    @testset "has-ancestor? without a captured node warns" begin
+        result =
+            @test_logs (:warn, r"requires access to node structure") match_mode = :any predicate_captures(
+                tree_sitter_c_jll,
+                "int x;",
+                "((identifier) @x (#has-ancestor? \"a\" \"b\"))",
+            )
+        @test isempty(result)
+    end
+
+    @testset "unknown predicate warns and filters" begin
+        result =
+            @test_logs (:warn, r"unknown predicate function 'bogus\?'") match_mode = :any predicate_captures(
+                tree_sitter_c_jll,
+                "int x;",
+                "((identifier) @x (#bogus? @x))",
+            )
+        @test isempty(result)
+    end
+
+    @testset "is? built-in properties" begin
+        # `missing`/`extra` are false for a plain identifier, so the pattern is filtered out.
+        @test isempty(
+            predicate_captures(
+                tree_sitter_c_jll,
+                "int x;",
+                "((identifier) @x (#is? missing))",
+            ),
+        )
+        @test isempty(
+            predicate_captures(
+                tree_sitter_c_jll,
+                "int x;",
+                "((identifier) @x (#is? extra))",
+            ),
+        )
+    end
+
+    @testset "is-not? built-in properties" begin
+        # An identifier is named, so `(#is-not? named)` filters it out.
+        @test isempty(
+            predicate_captures(
+                tree_sitter_c_jll,
+                "int x;",
+                "((identifier) @x (#is-not? named))",
+            ),
+        )
+        # An identifier is not missing, so `(#is-not? missing)` keeps it.
+        @test predicate_captures(
+            tree_sitter_c_jll,
+            "int x;",
+            "((identifier) @x (#is-not? missing))",
+        ) == ["x"]
+    end
+end
+
+@testset "Predicate construction errors" begin
+    @test_throws ErrorException Query(tree_sitter_c_jll, "((identifier) @v (#set!))")
+    @test_throws ErrorException Query(tree_sitter_c_jll, "((identifier) @v (#set! @v))")
+    @test_throws ErrorException Query(tree_sitter_c_jll, "((identifier) @v (#is?))")
+    @test_throws ErrorException Query(tree_sitter_c_jll, "((identifier) @v (#is? @v))")
+end
+
+@testset "Capture-level set! property" begin
+    p = Parser(tree_sitter_julia_jll)
+    src = "f(x) = x + 1"
+    tree = parse(p, src)
+    q = Query(
+        tree_sitter_julia_jll,
+        """
+        ((identifier) @v
+         (#set! @v "scope" "local")
+         (#set! "kind" "id"))
+        """,
+    )
+
+    m = first(eachmatch(q, tree))
+    c = first(TreeSitter.captures(m))
+    @test TreeSitter.property(q, c, "scope") == "local"
+    # Capture lookup falls back to a pattern-level property.
+    @test TreeSitter.property(q, c, "kind") == "id"
+    # Unset key falls through capture-specific and pattern-level lookups.
+    @test TreeSitter.property(q, c, "absent") === nothing
+    # Match-level lookup of a capture-only property returns nothing.
+    @test TreeSitter.property(q, m, "scope") === nothing
+end
+
+@testset "Query and node accessors" begin
+    p = Parser(tree_sitter_julia_jll)
+    tree = parse(p, "f(x) = x")
+    q = Query(tree_sitter_julia_jll, "(identifier) @id (integer_literal) @num")
+    @test TreeSitter.capture_count(q) == 2
+    @test TreeSitter.string_count(q) isa Integer
+    @test repr(q) == "Query(Language(:julia))"
+    @test repr(TreeSitter.QueryCursor()) == "QueryCursor()"
+
+    leaf = TreeSitter.child(TreeSitter.child(TreeSitter.root(tree), 1), 1)
+    @test TreeSitter.is_leaf(leaf) isa Bool
+end
+
+@testset "tokens" begin
+    p = Parser(tree_sitter_julia_jll)
+    q = Query(tree_sitter_julia_jll, "(identifier) @id")
+    toks = TreeSitter.tokens(p, q, "f(x) = x")
+    @test ("f", "id") in toks
+    @test ("x", "id") in toks
+end
+
+@testset "Language symbol constructor and errors" begin
+    q = Query(:julia, "(identifier) @x")
+    @test q.language.name == :julia
+    @test_throws ErrorException Language(:this_is_not_a_real_language)
+end
+
+@testset "show methods" begin
+    p = Parser(tree_sitter_julia_jll)
+    tree = parse(p, "f(x) = x")
+    @test repr(p.language) == "Language(:julia)"
+    @test occursin("Parser(Language(:julia))", repr(p))
+    @test occursin("source_file", repr(tree))
+    root_node = TreeSitter.root(tree)
+    @test TreeSitter.node_string(root_node) isa AbstractString
+    @test TreeSitter.node_symbol(root_node) isa Integer
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ using TreeSitter, Test
     include("introspection.jl")
     include("cursor.jl")
     include("editing.jl")
+    include("parser_control.jl")
     include("abstracttrees.jl")
     include("local_grammar.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ using TreeSitter, Test
     include("queries.jl")
     include("predicates.jl")
     include("introspection.jl")
+    include("cursor.jl")
     include("abstracttrees.jl")
     include("local_grammar.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ using TreeSitter, Test
     include("traversal.jl")
     include("nodes.jl")
     include("queries.jl")
+    include("predicates.jl")
     include("abstracttrees.jl")
     include("local_grammar.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,7 @@ using TreeSitter, Test
     include("predicates.jl")
     include("introspection.jl")
     include("cursor.jl")
+    include("editing.jl")
     include("abstracttrees.jl")
     include("local_grammar.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,7 @@ using TreeSitter, Test
     include("nodes.jl")
     include("queries.jl")
     include("predicates.jl")
+    include("introspection.jl")
     include("abstracttrees.jl")
     include("local_grammar.jl")
 end


### PR DESCRIPTION
Coverage sat at ~70% (codecov), mostly because `api.jl` bound the whole tree-sitter C-API but the package used only ~40 of 92 functions; the rest read as dead. Rather than exclude them, this wraps the unused bindings as real user-facing features, which covers them naturally. `src` coverage is now 98.7%, with a codecov gate to hold it.

New public API (all TDD'd, docstringed, unexported like the existing accessors):

- **Node health / lookup**: `has_error`, `has_changes`, `descendant_for_*` range lookup, `child_by_field_id`
- **Grammar introspection**: symbol and field metadata, resolvable from a `Language`, `Tree`, or `Parser`
- **`TreeCursor`**: stateful traversal exposing the field name a node occupies
- **Incremental editing**: `edit!`, `copy(tree)`, reparse with an old tree, `changed_ranges`
- **Parser control**: `reset!`, UTF-16 and streaming-callback `parse`, included ranges, logging, DOT graphs
- **Query scoping**: byte/point cursor ranges, `disable_pattern!`/`disable_capture!`, `next_capture`

Wrapping the bindings surfaced **three latent ABI bugs** for the pinned tree-sitter 0.25: `TSTreeCursor` and `TSInput` structs were undersized (would corrupt any use), and `next_capture`/`set_included_ranges` were zero-arg stubs. Also **removed** four deprecated timeout/cancellation bindings (gone in tree-sitter 0.26).

A `tree_sitter_jll` bump to 0.26+ will need these struct layouts re-checked.