### PR TITLE
fix: memory leak, query-predicate segfault/correctness, and loading bugs

### DIFF
--- a/src/api.jl
+++ b/src/api.jl
@@ -826,8 +826,9 @@ function get_lang_ptr(jll_mod::Module, variant::Union{Symbol,Nothing} = nothing)
     return lang_ptr
 end
 
-# Editor preference for selecting query directories when multiple exist
-const EDITOR_PREFERENCE = ["neovim", "helix", "emacs", "zed"]
+# Editor preference for selecting query directories when multiple exist. "nvim" and
+# "neovim" are both common directory names for the same editor.
+const EDITOR_PREFERENCE = ["neovim", "nvim", "helix", "emacs", "zed"]
 
 function load_queries(jll_mod::Module, variant::Union{Symbol,Nothing} = nothing)
     # Determine which parser variant to load queries for
@@ -873,13 +874,23 @@ function load_queries(jll_mod::Module, variant::Union{Symbol,Nothing} = nothing)
         end
     end
 
-    # For each query, prefer non-lua version, then by editor preference
+    # For each query, prefer the non-lua version, then the canonical (shallowest) location,
+    # then editor preference. This keeps a top-level `queries/foo.scm` ahead of an
+    # editor-specific `queries/<editor>/foo.scm` copy.
     for (name, options) in all_queries
-        sort!(options, by = x -> (x[1], editor_rank(dirname(x[2]))))
+        sort!(options, by = x -> (x[1], _query_dir_rank(dirname(x[2]), base_dir)))
         dict[name] = read(options[1][2], String)
     end
 
     return dict
+end
+
+# Rank a query directory: shallower (closer to the canonical top-level `queries/`) wins,
+# with editor preference breaking ties among equally-deep directories.
+function _query_dir_rank(dir::String, base_dir::String)
+    rel = relpath(dir, base_dir)
+    depth = rel == "." ? 0 : count(==('/'), rel) + 1
+    return (depth, editor_rank(dir))
 end
 
 function find_query_dirs(base_dir::String)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -302,7 +302,14 @@ ensure_not_null(n::Node) =
 
 Base.show(io::IO, n::Node) = print(io, node_string(n))
 
-node_string(n::Node) = (ensure_not_null(n); unsafe_string(API.ts_node_string(n.ptr)))
+function node_string(n::Node)
+    ensure_not_null(n)
+    # ts_node_string returns a malloc'd C string that the caller must free.
+    ptr = API.ts_node_string(n.ptr)
+    str = unsafe_string(ptr)
+    Libc.free(ptr)
+    return str
+end
 node_symbol(n::Node) = (ensure_not_null(n); API.ts_node_symbol(n.ptr))
 node_type(n::Node) = (ensure_not_null(n); unsafe_string(API.ts_node_type(n.ptr)))
 
@@ -943,12 +950,29 @@ function Base.iterate(cursor::QueryCursor, state = nothing)
     return result === nothing ? nothing : (result, nothing)
 end
 
+# The number of matches is only known by exhausting the cursor; each QueryMatch now owns a
+# copy of its captures, so collecting/retaining matches is safe.
+Base.IteratorSize(::Type{QueryCursor}) = Base.SizeUnknown()
+Base.eltype(::Type{QueryCursor}) = QueryMatch
+
 mutable struct QueryMatch
-    obj::API.TSQueryMatch
+    id::UInt32
+    pattern_index::UInt16
+    # Eager copy of the captures. The C `captures` pointer is owned by the cursor and is
+    # invalidated by the next `next_match`/`next_capture`, so we copy it out immediately to
+    # keep retained matches safe after the cursor advances.
+    captures::Vector{API.TSQueryCapture}
     tree::Tree
 end
 
-capture_count(qm::QueryMatch) = Int(qm.obj.capture_count)
+# Build a QueryMatch from a raw TSQueryMatch, copying its captures while the C pointer is
+# still valid.
+function QueryMatch(obj::API.TSQueryMatch, tree::Tree)
+    caps = [unsafe_load(obj.captures, i) for i = 1:Int(obj.capture_count)]
+    return QueryMatch(obj.id, obj.pattern_index, caps, tree)
+end
+
+capture_count(qm::QueryMatch) = length(qm.captures)
 
 function next_match(cursor::QueryCursor)
     match_ref = Ref{API.TSQueryMatch}()
@@ -963,8 +987,11 @@ end
 Restrict the cursor's matches to a range. Call before `exec`. Byte offsets are 1-based;
 points are 0-based `TSPoint` values.
 """
+# `byte_range` returns inclusive 1-based (from, to); tree-sitter wants a half-open 0-based
+# [start, end) range, so the exclusive end is `to`, not `to - 1`. Passing `to - 1` would
+# turn `to == 1` into C end_byte 0, which tree-sitter reinterprets as "unbounded".
 set_byte_range!(c::QueryCursor, from::Integer, to::Integer) =
-    (API.ts_query_cursor_set_byte_range(c.ptr, from - 1, to - 1); c)
+    (API.ts_query_cursor_set_byte_range(c.ptr, from - 1, to); c)
 set_point_range!(c::QueryCursor, from::API.TSPoint, to::API.TSPoint) =
     (API.ts_query_cursor_set_point_range(c.ptr, from, to); c)
 
@@ -997,9 +1024,9 @@ end
 
 function captures(qm::QueryMatch)
     fn = function (ith)
-        ptr = unsafe_load(qm.obj.captures, ith)
-        node = Node(ptr.node, qm.tree)
-        return QueryCapture(node, ptr.index, qm.obj.pattern_index)
+        cap = qm.captures[ith]
+        node = Node(cap.node, qm.tree)
+        return QueryCapture(node, cap.index, qm.pattern_index)
     end
     return (fn(i) for i = 1:capture_count(qm))
 end
@@ -1022,7 +1049,7 @@ end
 ```
 """
 function property(q::Query, m::QueryMatch, key::String)
-    props = property_settings(q, Int(m.obj.pattern_index) + 1)  # C uses 0-based
+    props = property_settings(q, Int(m.pattern_index) + 1)  # C uses 0-based
     for prop in props
         if prop.key == key && prop.capture_id === nothing
             return prop.value
@@ -1070,11 +1097,26 @@ query_string(q, id) =
 # A single predicate from a query pattern: its name, the resolved string
 # arguments, the captured nodes among those arguments, and every value bound to
 # each captured argument (a capture may be quantified and match several nodes).
+# `arg_is_capture` runs parallel to `args`: true where the argument came from a
+# capture, false for a string literal. Predicates that need the literal (e.g.
+# #is?) use it to tell a property name from captured node text.
 struct PredicateCall
     func::String
     args::Vector{String}
+    arg_is_capture::Vector{Bool}
     nodes::Vector{Node}
     capture_args::Dict{Int,Vector{String}}
+end
+
+# Compile a predicate regex, warning and returning `nothing` (rather than
+# throwing) when the pattern is not valid for Julia's regex engine.
+function _try_regex(pat::AbstractString)
+    try
+        return Regex(pat)
+    catch
+        @warn "invalid regex in predicate: $(repr(pat))"
+        return nothing
+    end
 end
 
 # Decode tree-sitter's flat predicate-step stream for a match into one
@@ -1084,9 +1126,9 @@ end
 # argument. A done step closes the current predicate.
 function parse_predicate_calls(q::Query, m::QueryMatch, source::AbstractString)
     len = Ref{UInt32}()
-    ptr = API.ts_query_predicates_for_pattern(q.ptr, m.obj.pattern_index, len)
+    ptr = API.ts_query_predicates_for_pattern(q.ptr, m.pattern_index, len)
     calls = PredicateCall[]
-    func, args, nodes = "", String[], Node[]
+    func, args, arg_is_capture, nodes = "", String[], Bool[], Node[]
     capture_args = Dict{Int,Vector{String}}()
     for i = 1:len[]
         step = unsafe_load(ptr, i)
@@ -1094,7 +1136,7 @@ function parse_predicate_calls(q::Query, m::QueryMatch, source::AbstractString)
             arg_idx = length(args) + 1
             values, capture_nodes = String[], Node[]
             for address = 1:capture_count(m)
-                capture = unsafe_load(m.obj.captures, address)
+                capture = m.captures[address]
                 if capture.index == step.value_id
                     node = Node(capture.node, m.tree)
                     push!(values, slice(source, node))
@@ -1103,16 +1145,32 @@ function parse_predicate_calls(q::Query, m::QueryMatch, source::AbstractString)
             end
             if !isempty(values)
                 push!(args, values[1])
+                push!(arg_is_capture, true)
                 push!(nodes, capture_nodes[1])
                 capture_args[arg_idx] = values
             end
         elseif step.type === API.TSQueryPredicateStepTypeString
             str = query_string(q, step.value_id)
-            func == "" ? (func = str) : push!(args, str)
+            if func == ""
+                func = str
+            else
+                push!(args, str)
+                push!(arg_is_capture, false)
+            end
         elseif step.type === API.TSQueryPredicateStepTypeDone
-            push!(calls, PredicateCall(func, copy(args), copy(nodes), copy(capture_args)))
+            push!(
+                calls,
+                PredicateCall(
+                    func,
+                    copy(args),
+                    copy(arg_is_capture),
+                    copy(nodes),
+                    copy(capture_args),
+                ),
+            )
             func = ""
             empty!(args)
+            empty!(arg_is_capture)
             empty!(nodes)
             empty!(capture_args)
         else
@@ -1140,7 +1198,9 @@ eval_not_eq(c::PredicateCall) = check_arity(c, 2) && c.args[1] != c.args[2]
 
 function eval_match(c::PredicateCall; negate::Bool)
     check_arity(c, 2) || return false
-    matched = occursin(Regex(c.args[2]), c.args[1])
+    rx = _try_regex(c.args[2])
+    rx === nothing && return false
+    matched = occursin(rx, c.args[1])
     return negate ? !matched : matched
 end
 
@@ -1174,14 +1234,16 @@ end
 function eval_any_match(c::PredicateCall)
     check_arity(c, 2) || return false
     values, comparison = quantified_args(c)
-    pattern = Regex(comparison[1])
+    pattern = _try_regex(comparison[1])
+    pattern === nothing && return false
     return any(cv -> occursin(pattern, cv), values)
 end
 
 function eval_any_not_match(c::PredicateCall)
     check_arity(c, 2) || return false
     values, comparison = quantified_args(c)
-    pattern = Regex(comparison[1])
+    pattern = _try_regex(comparison[1])
+    pattern === nothing && return false
     return any(cv -> !occursin(pattern, cv), values)
 end
 
@@ -1200,22 +1262,25 @@ function eval_has_ancestor(c::PredicateCall)
     return false
 end
 
-# Built-in property checks (`named`, `missing`, `extra`). The capture-ref forms
-# `(#is? @c "prop")` and `(#is? prop)` put the property in arg 2 or arg 1. When
-# no node was captured, fall back to the match's first capture. Unknown
-# properties (e.g. `local` from locals.scm) are no-ops that keep the pattern, so
-# both `is?` and `is-not?` return true for them.
+# Built-in property checks (`named`, `missing`, `extra`). The property is the
+# string-literal argument, not captured node text, so select the first
+# non-capture arg. The node tested is an explicit capture's node, else the
+# match's first capture; bail out (rather than read out of bounds) when neither
+# exists. Unknown properties (e.g. `local` from locals.scm) are no-ops that keep
+# the pattern, so both `is?` and `is-not?` return true for them.
 function eval_is(c::PredicateCall, m::QueryMatch; negate::Bool)
-    if isempty(c.args)
-        @warn "incorrect number of arguments to '$(c.func)', expected property name"
-        return false
-    end
-    property_name = startswith(c.args[1], "@") ? get(c.args, 2, "") : c.args[1]
+    lit_idx = findfirst(!, c.arg_is_capture)
+    property_name = lit_idx === nothing ? "" : c.args[lit_idx]
+    node =
+        !isempty(c.nodes) ? c.nodes[1] :
+        capture_count(m) > 0 ? Node(m.captures[1].node, m.tree) : nothing
     if isempty(property_name)
         @warn "'$(c.func)' missing property name"
         return false
+    elseif node === nothing
+        @warn "'$(c.func)' requires a captured node"
+        return false
     end
-    node = isempty(c.nodes) ? Node(unsafe_load(m.obj.captures, 1).node, m.tree) : c.nodes[1]
     held = if property_name == "named"
         is_named(node)
     elseif property_name == "missing"

--- a/test/bugfixes.jl
+++ b/test/bugfixes.jl
@@ -1,0 +1,141 @@
+import tree_sitter_c_jll
+
+# Regression tests for bugs found during the bug-exploration audit. Each testset encodes
+# the correct (post-fix) behavior and fails on the unfixed code.
+
+# Collect the text of every capture a query yields, evaluating all predicates.
+function _bf_captures(jll, src, qsrc)
+    p = Parser(jll)
+    tree = parse(p, src)
+    q = Query(jll, qsrc)
+    return collect(
+        TreeSitter.slice(src, c.node) for c in TreeSitter.each_capture(tree, q, src)
+    )
+end
+
+@testset "Bug regressions" begin
+    @testset "#1 node_string does not leak (resident memory stays bounded)" begin
+        if Sys.islinux()
+            rss() = Base.parse(Int, split(read("/proc/self/statm", String))[2]) * 4096
+            p = Parser(tree_sitter_c_jll)
+            root = TreeSitter.root(parse(p, "int x = 1 + 2 * 3;"))
+            for _ = 1:1000
+                TreeSitter.node_string(root)
+            end
+            GC.gc()
+            before = rss()
+            for _ = 1:500_000
+                TreeSitter.node_string(root)
+            end
+            GC.gc()
+            growth = rss() - before
+            # The leak was ~256 bytes/call (~128 MB over 500k). Allow generous slack.
+            @test growth < 30_000_000
+        end
+    end
+
+    @testset "#2 captureless is?/is-not? predicate does not segfault" begin
+        # Runs in a child process: on the unfixed code this segfaults (signal 11) at the
+        # unguarded `unsafe_load(m.obj.captures, 1)`. A clean exit means it is fixed.
+        script = """
+        using TreeSitter
+        import tree_sitter_c_jll
+        p = Parser(tree_sitter_c_jll)
+        tree = parse(p, "int x;")
+        for qsrc in ("((identifier) (#is? named))", "((identifier) (#is-not? extra))")
+            q = Query(tree_sitter_c_jll, qsrc)
+            cur = TreeSitter.eachmatch(q, tree)
+            m = TreeSitter.next_match(cur)
+            TreeSitter.predicate(q, m, "int x;")
+        end
+        print("OK")
+        """
+        cmd = `$(Base.julia_cmd()) --project=$(Base.active_project()) -e $script`
+        out = IOBuffer()
+        ok = success(pipeline(cmd; stdout = out, stderr = devnull))
+        @test ok
+    end
+
+    @testset "#3 is?/is-not? with explicit @capture honors the property" begin
+        # `x` is an identifier: named, not missing, not extra.
+        @test isempty(
+            _bf_captures(
+                tree_sitter_c_jll,
+                "int x;",
+                "((identifier) @v (#is? @v \"missing\"))",
+            ),
+        )
+        @test isempty(
+            _bf_captures(
+                tree_sitter_c_jll,
+                "int x;",
+                "((identifier) @v (#is-not? @v \"named\"))",
+            ),
+        )
+        # Positive assertions still keep the node.
+        @test _bf_captures(
+            tree_sitter_c_jll,
+            "int x;",
+            "((identifier) @v (#is? @v \"named\"))",
+        ) == ["x"]
+        @test _bf_captures(
+            tree_sitter_c_jll,
+            "int x;",
+            "((identifier) @v (#is-not? @v \"missing\"))",
+        ) == ["x"]
+    end
+
+    @testset "#4 set_byte_range! is not off-by-one (to==1 stays bounded)" begin
+        p = Parser(tree_sitter_c_jll)
+        src = "int x; int y;"
+        tree = parse(p, src)
+        q = Query(tree_sitter_c_jll, "(identifier) @id")
+        captext(c) =
+            [TreeSitter.slice(src, cap.node) for m in c for cap in TreeSitter.captures(m)]
+
+        # to==1 must NOT be reinterpreted as "unbounded" (C end_byte 0 => UINT32_MAX).
+        c1 = TreeSitter.QueryCursor()
+        TreeSitter.set_byte_range!(c1, 1, 1)
+        TreeSitter.exec(c1, q, tree)
+        @test isempty(captext(c1))
+
+        # A real sub-range still scopes to the first declaration.
+        c2 = TreeSitter.QueryCursor()
+        TreeSitter.set_byte_range!(c2, 1, 6)
+        TreeSitter.exec(c2, q, tree)
+        @test captext(c2) == ["x"]
+    end
+
+    @testset "#5 invalid regex in #match? warns and filters (no throw)" begin
+        local result
+        @test_logs (:warn,) match_mode = :any begin
+            result = _bf_captures(
+                tree_sitter_c_jll,
+                "int x;",
+                "((identifier) @v (#match? @v \"(\"))",
+            )
+        end
+        @test isempty(result)
+    end
+
+    @testset "#8 retained matches keep valid captures after the cursor advances" begin
+        p = Parser(tree_sitter_c_jll)
+        src = "int aa; int bb; int cc;"
+        tree = parse(p, src)
+        q = Query(tree_sitter_c_jll, "(identifier) @v")
+        ms = collect(eachmatch(q, tree))   # advance the cursor fully, THEN read captures
+        texts = [TreeSitter.slice(src, first(TreeSitter.captures(m)).node) for m in ms]
+        @test texts == ["aa", "bb", "cc"]
+    end
+
+    @testset "#6/#7 query-file selection prefers canonical over editor subdir; knows nvim" begin
+        API = TreeSitter.API
+        # #7: the common `nvim` directory name must be recognized (not the fallback rank).
+        @test API.editor_rank(joinpath("x", "queries", "nvim")) !=
+              length(API.EDITOR_PREFERENCE) + 1
+        # #6: a canonical top-level queries dir (depth 0) outranks an editor subdir (depth 1).
+        base = joinpath("repo", "queries")
+        @test API._query_dir_rank(base, base) <
+              API._query_dir_rank(joinpath(base, "neovim"), base)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,4 +12,5 @@ using TreeSitter, Test
     include("parser_control.jl")
     include("abstracttrees.jl")
     include("local_grammar.jl")
+    include("bugfixes.jl")
 end


### PR DESCRIPTION
Fixes found during a bug-exploration audit, each covered by a regression
test in test/bugfixes.jl:

- node_string: free the malloc'd string returned by ts_node_string
  (was leaking ~256 B per call; hit by every show(::Node)/show(::Tree)).
- QueryMatch: store an eager copy of the captures instead of the
  cursor-owned pointer, so retained/collected matches stay valid after
  the cursor advances (use-after-free). Also makes QueryCursor
  collectable (IteratorSize/eltype).
- predicate (#is?/#is-not?): select the property from the string-literal
  argument rather than misreading captured node text, and guard the node
  lookup so a captureless match no longer reads out of bounds (segfault).
- set_byte_range!: use a half-open exclusive end (to, not to-1); to==1
  no longer collapses to an unbounded range.
- #match?/#not-match?/#any-match?/#any-not-match?: compile the regex
  defensively, warning and filtering on an invalid pattern instead of
  throwing.
- load_queries: prefer the canonical top-level queries dir over editor
  subdirs, and recognise the common nvim/ directory name.