### PR TITLE
feat(injection): parse embedded languages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,11 +33,12 @@ include("test/runtests.jl")
 2. **Interface Layer (`src/interface.jl`)**: Julia-friendly wrapper types
    - `list_parsers(jll_mod)`: Discovers available parser variants in a JLL module
    - `Language`: Wraps language pointer with name symbol, supports optional `variant` parameter
-   - `Parser`: Manages parser state, auto-finalizes via GC, supports optional `variant` parameter
-   - `Tree` and `Node`: Represent parse trees, `Node` uses value type wrapping `API.TSNode`
+   - `Parser`: Manages parser state, auto-finalizes via GC, supports optional `variant` parameter and a `languages` injection set
+   - `Tree` and `Node`: Represent parse trees, `Node` uses value type wrapping `API.TSNode`; a `Tree` is also the root layer of its injection tree, carrying `source`, `language`, injected `children`, and root `unresolved`
    - `Query` and `QueryCursor`: Pattern matching with tree-sitter query syntax, supports optional `variant` parameter
    - Core APIs: `parse()`, `traverse()`, `children()`, `named_children()`
-   - Query predicates: filtering predicates `eq?`, `not-eq?`, `match?`, `not-match?`, `any-of?`, the quantified `any-eq?`/`any-not-eq?`/`any-match?`/`any-not-match?` family, and `has-ancestor?`; property checks `is?`/`is-not?` (built-in `named`/`missing`/`extra`, unknown properties are no-ops); `set!` attaches metadata read via `property_settings()`/`property()`
+   - Query predicates: filtering predicates `eq?`, `not-eq?`, `match?`, `not-match?`, `any-of?`, the quantified `any-eq?`/`any-not-eq?`/`any-match?`/`any-not-match?` family, and `has-ancestor?`; property checks `is?`/`is-not?` (built-in `named`/`missing`/`extra`, unknown properties are no-ops); `set!` attaches metadata read via `property_settings()`/`property()`. Directives (names ending in `!`) never filter a match
+   - Language injection (`src/injection.jl`): `ts_range` converts a `Node` to a 0-based `API.TSRange`; `injection_sites` runs a grammar's `injections.scm`, resolving static/dynamic languages and honoring `injection.combined`, `injection.include-children`, and single-line `#offset!`; `parse` recursively parses embedded languages into the returned `Tree`'s `children`, layers sharing one `source` string. A `Parser`'s `languages` set pins the injectable grammars (no dynamic loading); given none, injected languages resolve dynamically via `default_language_resolver`/`INJECTION_ALIASES`. Unavailable, cyclic, and over-depth sites land in the root tree's `unresolved`. Navigate layers with `layers`, `layer_at`, and `slice(::Tree)`
 
 3. **Module (`src/TreeSitter.jl`)**: Main entry point, exports public API
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add language injection: `parse` recursively parses embedded languages (JS/CSS in HTML, heredocs and phpdoc in PHP, tagged templates in JS) into a recursive `Tree` of layers over one shared source. A `Parser`'s `languages` set pins the injectable grammars, otherwise they resolve dynamically. Navigate with `layers`, `layer_at`, `slice`; analyse without parsing via `injection_sites` [#60]
 - Add node health accessors `has_error`/`has_changes` and byte/point descendant lookup [#50]
 - Add grammar introspection (symbol/field metadata) and query scoping by byte/point range [#50]
 - Add `TreeCursor` for stateful traversal with field-name access [#50]
@@ -22,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix query directives (`#offset!` and other `!`-suffixed names) being treated as failing filters, which dropped their matches from `each_capture` [#60]
 - Fix the zero-argument `ts_query_cursor_next_capture` binding signature [#50]
 - Fix the `TSTreeCursor` struct layout for the tree-sitter 0.25 ABI [#50]
 - Fix the zero-argument `ts_parser_set_included_ranges` binding signature [#50]
@@ -120,3 +122,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#44]: https://github.com/MichaelHatherly/TreeSitter.jl/issues/44
 [#50]: https://github.com/MichaelHatherly/TreeSitter.jl/issues/50
 [#54]: https://github.com/MichaelHatherly/TreeSitter.jl/issues/54
+[#60]: https://github.com/MichaelHatherly/TreeSitter.jl/issues/60

--- a/README.md
+++ b/README.md
@@ -234,3 +234,73 @@ q = query```
  (#any-match? @comments "TODO"))
 ```julia
 ```
+
+## Language Injection
+
+Many files embed one language in another: JavaScript and CSS inside HTML `<script>`/`<style>`, PHP inside HTML, heredocs and phpdoc inside PHP, regex and jsdoc inside JavaScript. Grammars describe these regions in an `injections.scm` query, marking the embedded text with `@injection.content` and naming the language either statically (`#set! injection.language "..."`) or dynamically (the text of an `@injection.language` capture). TreeSitter.jl reads those queries and parses the embedded languages for you.
+
+`parse` does the whole job; `injection_sites` stops at the analysis; `ts_range` is the low-level range helper.
+
+### Recursive parse
+
+`parse` parses a source and every language embedded in it, to a bounded depth. A `Tree` is recursive: it carries its `language`, the shared `source`, the `ranges` it covers, and the `children` layers for embedded languages. A grammar that declares no injections leaves a single-layer tree, so the plain case is the base case of an injected one.
+
+```julia
+tree = parse(Parser(:html), "<p>hi</p><script>f(x)</script>")
+
+tree.language.name                        # :html
+child = tree.children[1]
+child.language.name                       # :javascript
+TreeSitter.slice(child)                    # "f(x)"
+
+# The layer covering a 1-based byte offset, deepest first.
+TreeSitter.layer_at(tree, 20).language.name   # :javascript
+
+# Every layer, depth-first with the root first.
+[l.language.name for l in TreeSitter.layers(tree)]   # [:html, :javascript]
+```
+
+A sub-tree's node offsets stay in the original document's coordinate space, so a query on a child layer reports positions into the shared source:
+
+```julia
+q = Query(:javascript, "(call_expression) @c")
+for c in TreeSitter.each_capture(child, q, tree.source)
+    TreeSitter.slice(tree.source, c.node)   # "f(x)"
+end
+```
+
+### Language resolution
+
+Injected languages resolve dynamically by default: an injection name maps through `INJECTION_ALIASES` (case-insensitive, e.g. `"js"` to `:javascript`, `"c++"` to `:cpp`) to a grammar symbol, and the JLL loads on demand. Pass `Parser(lang; languages=[...])` to pin the set from JLL modules, `Language`s, or local grammar paths, which disables dynamic loading. A site whose grammar is unavailable is recorded in the root tree's `unresolved` rather than raised:
+
+```julia
+tree = parse(Parser(:html), "<style>a{}</style>")
+tree.unresolved   # [UnresolvedInjection("css", :unavailable)] when tree_sitter_css_jll is absent
+
+# Pin the grammars, including a local one, and skip dynamic loading:
+parse(Parser(:html; languages = [tree_sitter_javascript_jll, Language("path/to/tree-sitter-css")]), source)
+```
+
+Bound the recursion with `max_depth` (default 8); `max_depth=0` parses no embedded languages.
+
+### Analysis only
+
+`injection_sites` returns the embedded regions without parsing them, for callers that drive parsing themselves. Each `InjectionSite` carries the resolved language name, the 0-based `ranges`, and the `combined`/`include_children` flags.
+
+```julia
+p = Parser(:html)
+source = "<script>let x=1;</script><style>a{}</style>"
+tree = parse(p, source)
+for site in TreeSitter.injection_sites(p, tree, source)
+    site.language                                  # "javascript", then "css"
+    TreeSitter.slice(source, site.content_nodes[1])
+end
+```
+
+`ts_range(node)` builds the 0-based `API.TSRange` that `set_included_ranges!` expects, bridging the 1-based node coordinates and the 0-based C ranges.
+
+### Limitations
+
+- `include-children` follows tree-sitter's `intersect_ranges`: with the flag, the whole content node is injected; without it, every child node is excluded, leaving the gaps between them.
+- `#offset!` is applied to single-line adjustments only; a directive with a non-zero row delta falls back to the unadjusted range.
+- `injection.combined` groups content ranges by pattern index, matching how a grammar's own patterns combine.

--- a/src/TreeSitter.jl
+++ b/src/TreeSitter.jl
@@ -6,6 +6,7 @@ export list_parsers
 
 include("api.jl")
 include("interface.jl")
+include("injection.jl")
 include("abstracttrees.jl")
 
 end # module

--- a/src/injection.jl
+++ b/src/injection.jl
@@ -1,0 +1,434 @@
+#
+# Language injection
+#
+# Parsing embedded languages: JavaScript/CSS in HTML, PHP in HTML, heredocs and
+# phpdoc in PHP, regex and jsdoc in JavaScript. A grammar's `injections.scm`
+# marks the embedded regions with `@injection.content` and names the language
+# either statically (`#set! injection.language "..."`) or dynamically (the text
+# of an `@injection.language` capture). All layers share one source string; a
+# sub-parse positioned with `set_included_ranges!` keeps its node offsets in the
+# original document's coordinate space.
+#
+
+#
+# Layer 1 — range ergonomics
+#
+
+"""
+    ts_range(n::Node) -> API.TSRange
+
+Build the raw 0-based `API.TSRange` (byte and point fields) spanning `n`, ready for
+`set_included_ranges!`. Bridges the 1-based `Node`/`byte_range` world and the 0-based C
+range world.
+"""
+function ts_range(n::Node)
+    from, to = byte_range(n)
+    return API.TSRange(start_point(n), end_point(n), UInt32(from - 1), UInt32(to))
+end
+
+"""
+    ts_range(start_byte::Integer, end_byte::Integer, s::API.TSPoint, e::API.TSPoint) -> API.TSRange
+
+Construct a range from explicit 0-based half-open byte bounds and 0-based points.
+"""
+ts_range(start_byte::Integer, end_byte::Integer, s::API.TSPoint, e::API.TSPoint) =
+    API.TSRange(s, e, UInt32(start_byte), UInt32(end_byte))
+
+#
+# Layer 2 — injection site analysis
+#
+
+"""
+    InjectionSite
+
+One embedded-language region set discovered by an injections query. Does not parse.
+
+- `language`: injection name as written or derived (e.g. `"javascript"`, `"HTML"`).
+- `ranges`: 0-based, sorted, disjoint `API.TSRange`s to inject into.
+- `combined`: `#set! injection.combined` was present.
+- `include_children`: `#set! injection.include-children` was present.
+- `pattern_index`: 1-based query pattern that produced this site.
+- `content_nodes`: the `@injection.content` node(s).
+- `language_node`: the `@injection.language` node for a dynamic language, else `nothing`.
+"""
+struct InjectionSite
+    language::String
+    ranges::Vector{API.TSRange}
+    combined::Bool
+    include_children::Bool
+    pattern_index::Int
+    content_nodes::Vector{Node}
+    language_node::Union{Node,Nothing}
+end
+
+Base.show(io::IO, s::InjectionSite) =
+    print(io, "InjectionSite(", repr(s.language), ", ", length(s.ranges), " ranges)")
+
+# 0-based half-open bounds of a node as (start_byte, end_byte, start_point, end_point).
+function _node_bounds(n::Node)
+    from, to = byte_range(n)
+    return (from - 1, to, start_point(n), end_point(n))
+end
+
+# Apply a single-line #offset! delta (Δstart_row, Δstart_col, Δend_row, Δend_col) to a
+# node's bounds. Columns are byte columns, so byte and column deltas coincide. Multi-line
+# offsets are unsupported and fall back to the unadjusted bounds.
+function _apply_offset(bounds, off)
+    off === nothing && return bounds
+    sb, eb, sp, ep = bounds
+    dsr, dsc, der, dec = off
+    if dsr != 0 || der != 0
+        @warn "TreeSitter: multi-line #offset! is unsupported; using unadjusted range" maxlog =
+            1
+        return bounds
+    end
+    nsp = API.TSPoint(sp.row, UInt32(Int(sp.column) + dsc))
+    nep = API.TSPoint(ep.row, UInt32(Int(ep.column) + dec))
+    return (sb + dsc, eb + dec, nsp, nep)
+end
+
+# Ranges to inject for one content node. With `include_children` (or a childless node) the
+# whole content node is injected; otherwise every child is punched out, leaving only the gaps
+# between them (tree-sitter's `intersect_ranges`, which excludes all children, not only named).
+function content_ranges(node::Node, include_children::Bool, off = nothing)
+    sb, eb, sp, ep = _apply_offset(_node_bounds(node), off)
+    (include_children || count_nodes(node) == 0) && return [ts_range(sb, eb, sp, ep)]
+    out = API.TSRange[]
+    cur_byte, cur_pt = sb, sp
+    for c in children(node)
+        cf, _ = byte_range(c)
+        cb0 = cf - 1
+        cb0 > cur_byte && push!(out, ts_range(cur_byte, cb0, cur_pt, start_point(c)))
+        cur_byte, cur_pt = _node_bounds(c)[2], end_point(c)
+    end
+    eb > cur_byte && push!(out, ts_range(cur_byte, eb, cur_pt, ep))
+    return out
+end
+
+# Static #set! injection.language, else dynamic @injection.language capture text, else nothing.
+function _site_language(props, language_node, source)
+    for p in props
+        p.key == "injection.language" && p.value !== nothing && return p.value
+    end
+    language_node !== nothing && return String(slice(source, language_node))
+    return nothing
+end
+
+# (target_node, deltas) pairs for every #offset! directive on this match.
+function _match_offsets(query::Query, m::QueryMatch, source::AbstractString)
+    offs = Tuple{Node,NTuple{4,Int}}[]
+    for c in parse_predicate_calls(query, m, source)
+        c.func == "offset!" || continue
+        length(c.args) >= 5 && !isempty(c.nodes) || continue
+        push!(offs, (c.nodes[1], ntuple(i -> Base.parse(Int, c.args[i+1]), 4)))
+    end
+    return offs
+end
+
+function _offset_for(offs, node::Node)
+    for (n, d) in offs
+        n == node && return d
+    end
+    return nothing
+end
+
+"""
+    injection_sites(query::Query, tree::Tree, source::AbstractString) -> Vector{InjectionSite}
+    injection_sites(lang::Language, tree, source)
+    injection_sites(parser::Parser, tree, source)
+
+Run the injections `query` against `tree` and return the embedded-language regions it
+describes, resolving static and dynamic languages, honoring `#eq?`/`#match?` gating,
+`injection.combined`, `injection.include-children`, and single-line `#offset!`. Does not
+parse the regions; see [`parse_injected`](@ref).
+"""
+function injection_sites(query::Query, tree::Tree, source::AbstractString)
+    sites = InjectionSite[]
+    combined = Dict{Int,InjectionSite}()
+    for m in eachmatch(query, tree)
+        site = _match_site(query, m, source)
+        site === nothing && continue
+        site.combined ? _accumulate_combined!(combined, site) : push!(sites, site)
+    end
+    for site in values(combined)
+        unique!(sort!(site.ranges, by = r -> r.start_byte))
+        push!(sites, site)
+    end
+    sort!(sites, by = s -> isempty(s.ranges) ? typemax(UInt32) : s.ranges[1].start_byte)
+    return sites
+end
+
+# The @injection.content nodes and the first @injection.language node of a match.
+function _match_captures(query::Query, m::QueryMatch)
+    content_nodes = Node[]
+    language_node = nothing
+    for cap in captures(m)
+        name = capture_name(query, cap)
+        if name == "injection.content"
+            push!(content_nodes, cap.node)
+        elseif name == "injection.language" && language_node === nothing
+            language_node = cap.node
+        end
+    end
+    return content_nodes, language_node
+end
+
+# Non-empty injection ranges for a match's content nodes, offsets applied.
+function _site_ranges(content_nodes, include_children, offs)
+    ranges = API.TSRange[]
+    for cn in content_nodes
+        for r in content_ranges(cn, include_children, _offset_for(offs, cn))
+            r.end_byte > r.start_byte && push!(ranges, r)
+        end
+    end
+    return ranges
+end
+
+# One InjectionSite for a match, or nothing when it is gated out, has no content, or
+# resolves to no language or no ranges.
+function _match_site(query::Query, m::QueryMatch, source::AbstractString)
+    predicate(query, m, source) || return nothing
+    content_nodes, language_node = _match_captures(query, m)
+    isempty(content_nodes) && return nothing
+    pidx = Int(m.pattern_index) + 1
+    props = property_settings(query, pidx)
+    language = _site_language(props, language_node, source)
+    language === nothing && return nothing
+    include_children = any(p -> p.key == "injection.include-children", props)
+    ranges = _site_ranges(content_nodes, include_children, _match_offsets(query, m, source))
+    isempty(ranges) && return nothing
+    combined = any(p -> p.key == "injection.combined", props)
+    return InjectionSite(
+        language,
+        sort!(ranges, by = r -> r.start_byte),
+        combined,
+        include_children,
+        pidx,
+        content_nodes,
+        language_node,
+    )
+end
+
+# Merge a combined site into the accumulator keyed by pattern, mutating the stored vectors.
+function _accumulate_combined!(combined, site::InjectionSite)
+    prev = get(combined, site.pattern_index, nothing)
+    if prev === nothing
+        combined[site.pattern_index] = site
+    else
+        append!(prev.ranges, site.ranges)
+        append!(prev.content_nodes, site.content_nodes)
+    end
+    return combined
+end
+injection_sites(lang::Language, tree::Tree, source::AbstractString) =
+    injection_sites(Query(lang, ["injections"]), tree, source)
+injection_sites(parser::Parser, tree::Tree, source::AbstractString) =
+    injection_sites(parser.language, tree, source)
+
+
+#
+# Layer 3 — recursive injected parse
+#
+
+# Compile a layer's injections query, or nothing when the grammar ships none.
+function _injection_query(lang::Language)
+    src = get(lang.queries, "injections", "")
+    isempty(strip(src)) && return nothing
+    try
+        return Query(lang, ["injections"])
+    catch e
+        e isa QueryException || rethrow()
+        @warn "TreeSitter: failed to compile injections query for $(lang.name)" exception =
+            e
+        return nothing
+    end
+end
+
+_span(ranges) = (ranges[1].start_byte, maximum(r -> r.end_byte, ranges))
+
+"""
+    INJECTION_ALIASES :: Dict{String,Symbol}
+
+Maps lowercased injection language names to grammar symbols for
+[`default_language_resolver`](@ref).
+"""
+const INJECTION_ALIASES = Dict{String,Symbol}(
+    "js" => :javascript,
+    "javascript" => :javascript,
+    "ts" => :typescript,
+    "typescript" => :typescript,
+    "c" => :c,
+    "cpp" => :cpp,
+    "c++" => :cpp,
+    "cxx" => :cpp,
+    "css" => :css,
+    "html" => :html,
+    "py" => :python,
+    "python" => :python,
+    "rb" => :ruby,
+    "ruby" => :ruby,
+    "rs" => :rust,
+    "rust" => :rust,
+    "sh" => :bash,
+    "bash" => :bash,
+    "go" => :go,
+    "java" => :java,
+    "json" => :json,
+    "php" => :php,
+    "regex" => :regex,
+    "jsdoc" => :jsdoc,
+    "phpdoc" => :phpdoc,
+)
+
+const _LANGUAGE_CACHE = Dict{Symbol,Union{Language,Nothing}}()
+
+# Map an injection name to a grammar symbol, applying INJECTION_ALIASES case-insensitively.
+_injection_symbol(name::AbstractString) =
+    get(INJECTION_ALIASES, lowercase(strip(name)), Symbol(lowercase(strip(name))))
+
+"""
+    default_language_resolver(name::AbstractString) -> Union{Language,Nothing}
+
+Map an injection language `name` to a `Language`, or `nothing` when its grammar is not
+available. Applies [`INJECTION_ALIASES`](@ref) then `Language(sym)`, caching results. This
+is the dynamic resolution a `Parser` uses when it was not given an explicit `languages` set.
+"""
+function default_language_resolver(name::AbstractString)
+    sym = _injection_symbol(name)
+    return get!(_LANGUAGE_CACHE, sym) do
+        try
+            Language(sym)
+        catch
+            nothing
+        end
+    end
+end
+
+# Resolve an injection name to a grammar. A parser given an explicit `languages` set resolves
+# only within it (no dynamic loading); otherwise it resolves dynamically.
+function resolve_injection_language(parser::Parser, name::AbstractString)
+    parser.injections === nothing && return default_language_resolver(name)
+    return get(parser.injections, _injection_symbol(name), nothing)
+end
+
+"""
+    resolve_injections!(tree::Tree, parser::Parser, max_depth::Integer) -> Tree
+
+Populate `tree.children` with the layers for every language embedded in `tree.source`, up to
+`max_depth` levels, and record sites that could not be parsed in `tree.unresolved`. Called by
+[`parse`](@ref); a grammar that declares no injections leaves `tree` a single layer.
+"""
+function resolve_injections!(tree::Tree, parser::Parser, max_depth::Integer)
+    isempty(tree.source) && return tree
+    _inject!(
+        tree,
+        parser,
+        0,
+        max_depth,
+        Set{Tuple{Symbol,UInt32,UInt32}}(),
+        tree.unresolved,
+    )
+    return tree
+end
+
+# Build one layer's children, appending unparseable sites to the shared `unresolved`
+# accumulator (the root tree's vector, so the root aggregates the whole recursion).
+function _inject!(tree::Tree, parser::Parser, depth, max_depth, visited, unresolved)
+    query = _injection_query(tree.language)
+    query === nothing && return tree
+    for site in injection_sites(query, tree, tree.source)
+        record(reason) =
+            push!(unresolved, UnresolvedInjection(site.language, site.ranges, reason))
+        if depth >= max_depth
+            record(:depth_limit)
+            continue
+        end
+        sublang = resolve_injection_language(parser, site.language)
+        if sublang === nothing
+            record(:unavailable)
+            continue
+        end
+        # A layer's own (language, span) is in `visited`, so an injection that repeats it is
+        # caught here as a cycle.
+        span = (sublang.name, _span(site.ranges)...)
+        if span in visited
+            record(:cycle)
+            continue
+        end
+        subparser = Parser(sublang)
+        subparser.injections = parser.injections
+        try
+            set_included_ranges!(subparser, site.ranges)
+        catch e
+            e isa ArgumentError || rethrow()
+            record(:overlapping)
+            continue
+        end
+        subptr = API.ts_parser_parse_string(
+            subparser.ptr,
+            C_NULL,
+            tree.source,
+            sizeof(tree.source),
+        )
+        child = _tree(subptr, sublang, tree.source, site.ranges, site.combined)
+        _inject!(
+            child,
+            subparser,
+            depth + 1,
+            max_depth,
+            union(visited, (span,)),
+            unresolved,
+        )
+        push!(tree.children, child)
+    end
+    return tree
+end
+
+#
+# Injection tree accessors
+#
+
+"""
+    layers(tree::Tree) -> Vector{Tree}
+
+Every layer of `tree`, depth-first with the root first.
+"""
+function layers(tree::Tree)
+    out = Tree[]
+    walk(t) = (push!(out, t); foreach(walk, t.children))
+    walk(tree)
+    return out
+end
+
+"""
+    layer_at(tree::Tree, byte::Integer) -> Tree
+
+The deepest layer whose ranges contain the 1-based `byte`. `tree` itself is returned when no
+deeper layer matches.
+"""
+function layer_at(tree::Tree, byte::Integer)
+    b = UInt32(byte - 1)
+    best = tree
+    function descend(t)
+        for c in t.children
+            if any(r -> r.start_byte <= b < r.end_byte, c.ranges)
+                best = c
+                descend(c)
+            end
+        end
+    end
+    descend(tree)
+    return best
+end
+
+"""
+    slice(tree::Tree) -> AbstractString
+
+The source text `tree` covers: the whole source for the root, otherwise its ranges joined.
+"""
+function slice(tree::Tree)
+    isempty(tree.ranges) && return tree.source
+    return join(
+        slice(tree.source, (Int(r.start_byte) + 1, Int(r.end_byte))) for r in tree.ranges
+    )
+end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -40,11 +40,12 @@ mutable struct Language
             pkg_id = Base.identify_package(pkg_name)
             if pkg_id === nothing
                 error(
-                    "Language package '$pkg_name' not found. Please add and import it first:\n" *
-                    "  using tree_sitter_$(name)_jll",
+                    "Language package '$pkg_name' not found. Add it to the active project:\n" *
+                    "  import Pkg; Pkg.add(\"tree_sitter_$(name)_jll\")",
                 )
             end
-            Base.root_module(pkg_id)
+            # Load on demand: a grammar in the active project need not be imported first.
+            Base.require(pkg_id)
         end
         return Language(jll_mod)
     end
@@ -69,19 +70,37 @@ mutable struct Parser
     language::Language
     ptr::Ptr{API.TSParser}
     logger_sink::Union{Function,Nothing}  # keeps a set_logger! callback alive while installed
-    function Parser(lang::Language)
-        parser = new(lang, API.ts_parser_new(), nothing)
+    # Grammars available to language injection. `nothing` resolves injected languages
+    # dynamically at parse time; a dict pins the set and disables dynamic loading.
+    injections::Union{Nothing,Dict{Symbol,Language}}
+    function Parser(lang::Language; languages = nothing)
+        registry = languages === nothing ? nothing : injection_registry(languages)
+        parser = new(lang, API.ts_parser_new(), nothing, registry)
         finalizer(p -> API.ts_parser_delete(p.ptr), parser)
         set_language!(parser, lang)
         return parser
     end
-    Parser(jll_mod::Module, variant::Union{Symbol,Nothing} = nothing) =
-        Parser(Language(jll_mod, variant))
-    Parser(name::Symbol) = Parser(Language(name))
-    Parser(path::AbstractString, variant::Union{Symbol,Nothing} = nothing) =
-        Parser(Language(path, variant))
+    Parser(jll_mod::Module, variant::Union{Symbol,Nothing} = nothing; languages = nothing) =
+        Parser(Language(jll_mod, variant); languages)
+    Parser(name::Symbol; languages = nothing) = Parser(Language(name); languages)
+    Parser(
+        path::AbstractString,
+        variant::Union{Symbol,Nothing} = nothing;
+        languages = nothing,
+    ) = Parser(Language(path, variant); languages)
 end
 Base.show(io::IO, p::Parser) = print(io, "Parser(", p.language, ")")
+
+# Build the injection grammar registry from a collection of languages, each given as a
+# `Language`, a JLL `Module`, a grammar `Symbol`, or a local grammar path `String`.
+function injection_registry(languages)
+    registry = Dict{Symbol,Language}()
+    for entry in languages
+        lang = entry isa Language ? entry : Language(entry)
+        registry[lang.name] = lang
+    end
+    return registry
+end
 
 function set_language!(parser::Parser, language::Language)
     API.ts_parser_set_language(parser.ptr, language.ptr)
@@ -90,15 +109,21 @@ function set_language!(parser::Parser, language::Language)
 end
 
 """
-    parse(parser::Parser, text::AbstractString; encoding=:utf8) -> Tree
+    parse(parser::Parser, text::AbstractString; encoding=:utf8, max_depth=8) -> Tree
     parse(parser::Parser, source::Function; encoding=:utf8) -> Tree
-    parse(parser::Parser, text::AbstractString, old::Tree) -> Tree
+    parse(parser::Parser, text::AbstractString, old::Tree; max_depth=8) -> Tree
 
 Parse source into a `Tree`. `encoding` is `:utf8` or `:utf16`.
 
+Languages embedded via the grammar's injections query are parsed too, up to `max_depth`
+levels, and hang off `tree.children`; a grammar that declares no injections leaves a
+single-layer tree. The parser resolves injected languages from its `languages` set, or
+dynamically when it was given none. Sites that could not be parsed are recorded in
+`tree.unresolved`. See [`Tree`](@ref), [`layers`](@ref), [`layer_at`](@ref).
+
 Pass a `source` callback to parse a source not held as a single `String`:
 `source(offset)` returns the chunk at a 1-based byte offset, or an empty string at end
-of input.
+of input. A callback-parsed tree has no shared source, so it is never injected into.
 
 Pass an `old` tree that has had the matching `edit!` applied to reparse incrementally,
 reusing the unchanged subtrees.
@@ -107,25 +132,38 @@ reusing the unchanged subtrees.
 ```julia
 parser = Parser(tree_sitter_julia_jll)
 tree = parse(parser, "f(x) = x + 1")
+
+html = parse(Parser(:html), "<script>f(x)</script>")
+html.children[1].language.name   # :javascript
 ```
 """
-function Base.parse(p::Parser, text::AbstractString; encoding::Symbol = :utf8)
-    encoding === :utf8 &&
-        return Tree(API.ts_parser_parse_string(p.ptr, C_NULL, text, sizeof(text)))
+# The raw tree-sitter parse of a string, returning the C tree pointer without wrapping.
+function _parse_string_ptr(p::Parser, text::AbstractString, old::Ptr, encoding::Symbol)
+    encoding === :utf8 && return API.ts_parser_parse_string(p.ptr, old, text, sizeof(text))
     encoding === :utf16 || throw(ArgumentError("unknown encoding $encoding"))
     units = transcode(UInt16, String(text))
     GC.@preserve units begin
         buffer = Cstring(reinterpret(Ptr{Cchar}, pointer(units)))
-        return Tree(
-            API.ts_parser_parse_string_encoding(
-                p.ptr,
-                C_NULL,
-                buffer,
-                UInt32(2 * length(units)),
-                API.TSInputEncodingUTF16LE,
-            ),
+        return API.ts_parser_parse_string_encoding(
+            p.ptr,
+            old,
+            buffer,
+            UInt32(2 * length(units)),
+            API.TSInputEncodingUTF16LE,
         )
     end
+end
+
+function Base.parse(
+    p::Parser,
+    text::AbstractString;
+    encoding::Symbol = :utf8,
+    max_depth::Integer = 8,
+)
+    ptr = _parse_string_ptr(p, text, C_NULL, encoding)
+    tree = _tree(ptr, p.language, text, API.TSRange[], false)
+    resolve_injections!(tree, p, max_depth)
+    return tree
 end
 
 # Holds the user's chunk producer and the current chunk, kept alive across read calls.
@@ -161,7 +199,10 @@ function Base.parse(p::Parser, source::Function; encoding::Symbol = :utf8)
     )
     GC.@preserve state begin
         input = API.TSInput(pointer_from_objref(state), trampoline, enc, C_NULL)
-        return Tree(API.ts_parser_parse(p.ptr, C_NULL, input))
+        ptr = API.ts_parser_parse(p.ptr, C_NULL, input)
+        # A callback source is not held as a single string, so there is nothing to inject
+        # over: the tree is one layer with no shared source.
+        return _tree(ptr, p.language, "", API.TSRange[], false)
     end
 end
 
@@ -262,28 +303,92 @@ _dup_fd(fd) = @static Sys.iswindows() ? ccall(:_dup, Cint, (Cint,), fd) :
 # Tree
 #
 
+"""
+    UnresolvedInjection
+
+An injection site discovered but not parsed. `reason` is one of `:unavailable` (no
+importable grammar), `:depth_limit`, `:cycle`, or `:overlapping` (rejected by
+`set_included_ranges!`).
+"""
+struct UnresolvedInjection
+    language::String
+    ranges::Vector{API.TSRange}
+    reason::Symbol
+end
+
+Base.show(io::IO, u::UnresolvedInjection) =
+    print(io, "UnresolvedInjection(", repr(u.language), ", ", u.reason, ")")
+
+"""
+    Tree
+
+A parse tree. A tree is also a layer of the injection tree rooted at it: `children` holds
+the layers for languages embedded in `source`, each parsed over its own `ranges` but sharing
+one `source` string, so every node's byte offsets stay in the original document's
+coordinates.
+
+- `language`: the grammar this layer was parsed with.
+- `source`: the whole document, shared by every layer (empty when parsed from a callback).
+- `ranges`: 0-based ranges this layer covers (empty for the root, which covers everything).
+- `combined`: this layer came from a `#set! injection.combined` site.
+- `children`: nested injection layers.
+- `unresolved`: on the root, every injection site discovered but not parsed; empty otherwise.
+"""
 mutable struct Tree
     ptr::Ptr{API.TSTree}
-    function Tree(ptr::Ptr{API.TSTree})
-        tree = new(ptr)
+    language::Language
+    source::String
+    ranges::Vector{API.TSRange}
+    combined::Bool
+    children::Vector{Tree}
+    unresolved::Vector{UnresolvedInjection}
+    function Tree(
+        ptr::Ptr{API.TSTree},
+        language::Language,
+        source::AbstractString,
+        ranges::Vector{API.TSRange},
+        combined::Bool,
+        children::Vector{Tree},
+        unresolved::Vector{UnresolvedInjection},
+    )
+        tree = new(ptr, language, String(source), ranges, combined, children, unresolved)
         finalizer(t -> API.ts_tree_delete(t.ptr), tree)
         return tree
     end
 end
-Base.show(io::IO, t::Tree) = show(io, root(t))
+
+# A leaf tree: one layer, no children or unresolved sites yet.
+_tree(ptr::Ptr{API.TSTree}, language::Language, source::AbstractString, ranges, combined) =
+    Tree(ptr, language, source, ranges, combined, Tree[], UnresolvedInjection[])
+
+Base.show(io::IO, t::Tree) =
+    isempty(t.children) ? show(io, root(t)) :
+    print(io, "Tree(", t.language.name, ", ", length(layers(t)), " layers)")
 
 root(t::Tree) = Node(API.ts_tree_root_node(t.ptr), t)
 
 """
     copy(tree::Tree) -> Tree
 
-Return an independent copy of `tree`, useful for keeping the pre-edit tree when reparsing
-incrementally.
+Return an independent copy of `tree` and its injection layers, useful for keeping the
+pre-edit tree when reparsing incrementally.
 """
-Base.copy(t::Tree) = Tree(API.ts_tree_copy(t.ptr))
+Base.copy(t::Tree) = Tree(
+    API.ts_tree_copy(t.ptr),
+    t.language,
+    t.source,
+    copy(t.ranges),
+    t.combined,
+    Tree[copy(c) for c in t.children],
+    copy(t.unresolved),
+)
 
-Base.parse(p::Parser, text::AbstractString, old::Tree) =
-    Tree(API.ts_parser_parse_string(p.ptr, old.ptr, text, sizeof(text)))
+function Base.parse(p::Parser, text::AbstractString, old::Tree; max_depth::Integer = 8)
+    ptr = API.ts_parser_parse_string(p.ptr, old.ptr, text, sizeof(text))
+    tree = _tree(ptr, p.language, text, API.TSRange[], false)
+    resolve_injections!(tree, p, max_depth)
+    return tree
+end
 
 traverse(f, tree::Tree, iter = children) = traverse(f, root(tree), iter)
 
@@ -1295,8 +1400,9 @@ function eval_is(c::PredicateCall, m::QueryMatch; negate::Bool)
     return negate ? !held : held
 end
 
-# Predicate names follow the tree-sitter rust library. `set!` is a metadata
-# directive parsed at construction, so as a filter it always passes.
+# Predicate names follow the tree-sitter rust library. Directives (names ending in
+# `!`, such as `set!` and `offset!`) annotate a match rather than filter it, so as
+# filters they always pass.
 function eval_predicate(c::PredicateCall, m::QueryMatch)
     if c.func == "eq?"
         eval_eq(c)
@@ -1322,7 +1428,7 @@ function eval_predicate(c::PredicateCall, m::QueryMatch)
         eval_any_match(c)
     elseif c.func == "any-not-match?"
         eval_any_not_match(c)
-    elseif c.func == "set!"
+    elseif endswith(c.func, "!")
         true
     else
         @warn "unknown predicate function '$(c.func)'"

--- a/test/injection.jl
+++ b/test/injection.jl
@@ -1,0 +1,201 @@
+import tree_sitter_html_jll, tree_sitter_javascript_jll, tree_sitter_php_jll
+
+# First named node of a given type, or nothing.
+function find_node(tree, ty)
+    result = nothing
+    traverse(tree) do n, enter
+        if enter && result === nothing && TreeSitter.node_type(n) == ty
+            result = n
+        end
+    end
+    return result
+end
+
+range_text(src, r) = TreeSitter.slice(src, (Int(r.start_byte) + 1, Int(r.end_byte)))
+
+@testset "Language injection" begin
+    @testset "ts_range conversion" begin
+        p = Parser(:javascript)
+        tree = parse(p, "f(x)")
+        n = TreeSitter.root(tree)
+        from, to = TreeSitter.byte_range(n)
+        r = TreeSitter.ts_range(n)
+        @test r.start_byte == from - 1
+        @test r.end_byte == to
+        @test r.start_point == TreeSitter.start_point(n)
+        @test r.end_point == TreeSitter.end_point(n)
+    end
+
+    @testset "injection_sites: HTML static" begin
+        source = "<script>let x=1;</script><style>a{}</style>"
+        p = Parser(:html)
+        tree = parse(p, source)
+        sites = TreeSitter.injection_sites(p, tree, source)
+        @test [s.language for s in sites] == ["javascript", "css"]
+        @test all(s -> !s.combined, sites)
+        @test TreeSitter.slice(source, sites[1].content_nodes[1]) == "let x=1;"
+        @test TreeSitter.slice(source, sites[2].content_nodes[1]) == "a{}"
+    end
+
+    @testset "injection_sites: PHP heredoc dynamic language" begin
+        # The language name comes from the `heredoc_end` capture's text, not a #set!.
+        source = "<?php\n\$x = <<<HTML\n<p>hi</p>\nHTML;\n"
+        p = Parser(tree_sitter_php_jll)
+        tree = parse(p, source)
+        sites = TreeSitter.injection_sites(p, tree, source)
+        @test "HTML" in [s.language for s in sites]
+    end
+
+    @testset "injection_sites: #offset! trims range" begin
+        p = Parser(:javascript)
+        source = "x = `abc`"
+        tree = parse(p, source)
+        q = Query(
+            :javascript,
+            """
+((template_string) @injection.content
+ (#set! injection.language "javascript")
+ (#set! injection.include-children)
+ (#offset! @injection.content 0 1 0 -1))
+""",
+        )
+        sites = TreeSitter.injection_sites(q, tree, source)
+        @test length(sites) == 1
+        @test range_text(source, sites[1].ranges[1]) == "abc"
+    end
+
+    @testset "#offset! multi-line falls back" begin
+        p = Parser(:javascript)
+        tree = parse(p, "f(x)")
+        n = TreeSitter.root(tree)
+        local r
+        @test_logs (:warn, r"multi-line") begin
+            r = TreeSitter.content_ranges(n, true, (1, 0, 0, 0))
+        end
+        @test r == [TreeSitter.ts_range(n)]
+    end
+
+    @testset "site without a language is skipped" begin
+        p = Parser(:javascript)
+        source = "f(x)"
+        tree = parse(p, source)
+        q = Query(:javascript, "((identifier) @injection.content)")
+        @test isempty(TreeSitter.injection_sites(q, tree, source))
+    end
+
+    @testset "combined injection merges ranges" begin
+        p = Parser(:javascript)
+        source = "js`a`; js`b`"
+        tree = parse(p, source)
+        combined =
+            only(filter(s -> s.combined, TreeSitter.injection_sites(p, tree, source)))
+        @test length(combined.ranges) == 2
+    end
+
+    @testset "show methods" begin
+        source = "<style>a{}</style><script>f()</script>"
+        tree = parse(Parser(:html), source)
+        @test occursin("Tree(html", repr(tree))
+        @test occursin("UnresolvedInjection", repr(only(tree.unresolved)))
+        site = first(TreeSitter.injection_sites(Parser(:html), tree, source))
+        @test occursin("InjectionSite", repr(site))
+    end
+
+    @testset "include-children hole punching" begin
+        p = Parser(:javascript)
+        source = "f(a, b)"
+        tree = parse(p, source)
+        args = find_node(tree, "arguments")
+        @test args !== nothing
+        incl = TreeSitter.content_ranges(args, true)
+        excl = TreeSitter.content_ranges(args, false)
+        @test length(incl) == 1
+        @test incl[1].start_byte == TreeSitter.byte_range(args)[1] - 1
+        incl_text = join(range_text(source, r) for r in incl)
+        excl_text = join(range_text(source, r) for r in excl)
+        @test occursin("a", incl_text) && occursin("b", incl_text)
+        @test !occursin("a", excl_text) && !occursin("b", excl_text)
+    end
+
+    @testset "parse: HTML into JavaScript" begin
+        source = "<p>hi</p><script>f(x)</script>"
+        tree = parse(Parser(:html), source)
+        @test tree.language.name == :html
+        @test length(tree.children) == 1
+        js = tree.children[1]
+        @test js.language.name == :javascript
+        @test TreeSitter.slice(js) == "f(x)"
+        # Sub-tree offsets live in the original document's coordinate space.
+        q = Query(:javascript, "(call_expression) @c")
+        calls = [
+            TreeSitter.slice(tree.source, c.node) for
+            c in TreeSitter.each_capture(js, q, tree.source)
+        ]
+        @test calls == ["f(x)"]
+    end
+
+    @testset "parse: grammar with no injections is a single layer" begin
+        tree = parse(Parser(:javascript), "f(x)")
+        @test isempty(tree.children)
+        @test isempty(tree.unresolved)
+        @test length(TreeSitter.layers(tree)) == 1
+    end
+
+    @testset "parse: unavailable language recorded" begin
+        tree = parse(Parser(:html), "<style>a{}</style>")
+        @test isempty(tree.children)
+        css = only(filter(u -> u.language == "css", tree.unresolved))
+        @test css.reason == :unavailable
+    end
+
+    @testset "parse: depth limit recorded" begin
+        tree = parse(Parser(:html), "<script>f(x)</script>"; max_depth = 0)
+        @test isempty(tree.children)
+        js = only(filter(u -> u.language == "javascript", tree.unresolved))
+        @test js.reason == :depth_limit
+    end
+
+    @testset "injection tree accessors" begin
+        source = "<p>hi</p><script>f(x)</script>"
+        tree = parse(Parser(:html), source)
+        @test length(TreeSitter.layers(tree)) == 2
+        inside = first(findfirst("f(x)", source))
+        @test TreeSitter.layer_at(tree, inside).language.name == :javascript
+        @test TreeSitter.layer_at(tree, 2).language.name == :html
+    end
+
+    @testset "parse: dynamic tagged template" begin
+        # `js` tags the template as JavaScript (dynamic @injection.language), with
+        # injection.combined and injection.include-children set.
+        source = "js`f(x)`"
+        tree = parse(Parser(:javascript), source)
+        child = only(tree.children)
+        @test child.language.name == :javascript
+        @test child.combined
+        @test TreeSitter.slice(child) == "f(x)"
+        q = Query(:javascript, "(call_expression) @c")
+        calls = [
+            TreeSitter.slice(tree.source, c.node) for
+            c in TreeSitter.each_capture(child, q, tree.source)
+        ]
+        @test "f(x)" in calls
+    end
+
+    @testset "parse: pinned languages disable dynamic loading" begin
+        source = "<style>a{}</style><script>f(x)</script>"
+        # Only javascript is offered, so css cannot resolve even though its alias is known.
+        tree = parse(Parser(:html; languages = [tree_sitter_javascript_jll]), source)
+        @test [c.language.name for c in tree.children] == [:javascript]
+        css = only(filter(u -> u.language == "css", tree.unresolved))
+        @test css.reason == :unavailable
+    end
+
+    @testset "parse: incremental reparse keeps injection layers" begin
+        p = Parser(:html)
+        old = parse(p, "<script>f(x)</script>")
+        tree = parse(p, "<script>g(y)</script>", old)
+        js = only(tree.children)
+        @test js.language.name == :javascript
+        @test TreeSitter.slice(js) == "g(y)"
+    end
+end

--- a/test/queries.jl
+++ b/test/queries.jl
@@ -594,3 +594,19 @@ end
     @test "unknown" in q.unknown_properties
     @test length(q.unknown_properties) == 1
 end
+
+@testset "Directives do not filter matches" begin
+    # #offset! (and any `!`-suffixed directive) annotates a match; it must not drop it.
+    p = Parser(tree_sitter_javascript_jll)
+    source = "x = `abc`"
+    tree = parse(p, source)
+    q = query```
+    ((template_string) @t
+     (#offset! @t 0 1 0 -1))
+    ```javascript
+    out = String[]
+    for cap in TreeSitter.each_capture(tree, q, source)
+        push!(out, TreeSitter.capture_name(q, cap))
+    end
+    @test out == ["t"]
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,4 +13,5 @@ using TreeSitter, Test
     include("abstracttrees.jl")
     include("local_grammar.jl")
     include("bugfixes.jl")
+    include("injection.jl")
 end


### PR DESCRIPTION
Parse languages embedded in a document by their own grammar: JavaScript and CSS in HTML, heredocs and phpdoc in PHP, tagged templates and regex in JavaScript. A grammar's injections query marks the regions and names the embedded language, statically or from a capture. Each region is parsed over the shared source, so a sub-tree's node offsets stay in the document's coordinate space.

A parse tree is recursive. `Tree` carries its `language`, the shared `source`, the `ranges` it covers, and the `children` layers for embedded languages. A grammar that declares no injections leaves a single-layer tree, so the plain parse is the base case of an injected one and no separate injection-tree type is needed. `parse` resolves injections eagerly; `layers`, `layer_at`, and `slice` walk the result, and `injection_sites` exposes the regions for callers that drive parsing themselves.

Injected grammars resolve dynamically by default, loading on demand through `INJECTION_ALIASES`. Pass `Parser(lang; languages=[...])` to pin the set from JLL modules, `Language`s, or local grammar paths, which disables dynamic loading. A site that cannot be parsed (grammar unavailable, cycle, depth limit) is recorded in the root tree's `unresolved` rather than raised.

The change is additive to the parsing API. `parse` still returns a `Tree`, and existing `root`, `traverse`, and `slice` calls are unchanged.

---

Consumed by JuliaDocs/Highlights.jl#88, which adds `inject=true` to its `highlight` on top of this layered `parse`. That PR's CI stays red until this merges and a release ships the injection API.