### PR TITLE
Compile a grammar's injections query once, and let a caller decline injection

### DIFF
--- a/src/injection.jl
+++ b/src/injection.jl
@@ -230,8 +230,38 @@ injection_sites(parser::Parser, tree::Tree, source::AbstractString) =
 # Layer 3 — recursive injected parse
 #
 
-# Compile a layer's injections query, or nothing when the grammar ships none.
-function _injection_query(lang::Language)
+# The compiled injections query per grammar. `Query(lang, ["injections"])` is a function of
+# the language alone: the source it reads is loaded once, when the `Language` is built. It
+# was compiled once per layer per parse instead, which put a query compile on the parse path
+# of every file.
+#
+# Keyed by language rather than by parser or by caller, because that is what the value
+# depends on. `_inject!` recurses into a child layer and asks again for *that* layer's
+# language, so anything keyed further out would cover the top layer alone and a document
+# embedding three languages would keep compiling per layer per parse.
+#
+# Entries live for the process, deliberately. One query per grammar ever loaded is bounded
+# by the grammars a program uses, and a `Query` holds its own `Language`, so weak keys would
+# keep every entry reachable and buy nothing. Identity-keyed: a `Language` wraps a grammar
+# pointer, and two of them built from one grammar are two caches, not a collision.
+const _INJECTION_QUERY_CACHE = IdDict{Language,Union{Query,Nothing}}()
+
+# Guards both grammar-derived caches. `parse` runs on whatever thread its caller is on, and
+# `get!` on a shared dictionary corrupts it when two of them resize it at once, so an entry
+# is taken under this rather than left to a race that looks benign until it is not.
+const _GRAMMAR_LOCK = ReentrantLock()
+
+# A layer's injections query, compiled on first use and reused after. A compiled `Query` is
+# immutable once constructed (its predicates are parsed there, and a `QueryCursor` carries
+# the per-match state), so one shared across concurrent parses is safe.
+_injection_query(lang::Language) = lock(_GRAMMAR_LOCK) do
+    get!(() -> _compile_injection_query(lang), _INJECTION_QUERY_CACHE, lang)
+end
+
+# Compile a layer's injections query, or nothing when the grammar ships none. A query that
+# does not compile warns and yields nothing; cached, so a broken grammar warns once rather
+# than once per parse.
+function _compile_injection_query(lang::Language)
     src = get(lang.queries, "injections", "")
     isempty(strip(src)) && return nothing
     try
@@ -295,11 +325,16 @@ is the dynamic resolution a `Parser` uses when it was not given an explicit `lan
 """
 function default_language_resolver(name::AbstractString)
     sym = _injection_symbol(name)
-    return get!(_LANGUAGE_CACHE, sym) do
-        try
-            Language(sym)
-        catch
-            nothing
+    # Under `_GRAMMAR_LOCK` for the reason the injections query is: a nested injection
+    # resolves its grammar during a parse, so two threads parsing at once enter this
+    # dictionary at once.
+    return lock(_GRAMMAR_LOCK) do
+        get!(_LANGUAGE_CACHE, sym) do
+            try
+                Language(sym)
+            catch
+                nothing
+            end
         end
     end
 end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -109,9 +109,9 @@ function set_language!(parser::Parser, language::Language)
 end
 
 """
-    parse(parser::Parser, text::AbstractString; encoding=:utf8, max_depth=8) -> Tree
+    parse(parser::Parser, text::AbstractString; encoding=:utf8, max_depth=8, injections=true) -> Tree
     parse(parser::Parser, source::Function; encoding=:utf8) -> Tree
-    parse(parser::Parser, text::AbstractString, old::Tree; max_depth=8) -> Tree
+    parse(parser::Parser, text::AbstractString, old::Tree; max_depth=8, injections=true) -> Tree
 
 Parse source into a `Tree`. `encoding` is `:utf8` or `:utf16`.
 
@@ -120,6 +120,12 @@ levels, and hang off `tree.children`; a grammar that declares no injections leav
 single-layer tree. The parser resolves injected languages from its `languages` set, or
 dynamically when it was given none. Sites that could not be parsed are recorded in
 `tree.unresolved`. See [`Tree`](@ref), [`layers`](@ref), [`layer_at`](@ref).
+
+`injections = false` skips that resolution: no injections query is run and no layer is
+built, so `children` and `unresolved` come back empty and the root layer is unchanged.
+This is for a caller that reads one language per source and never looks at a layer, where
+resolving them is work nothing downstream can see. It differs from `max_depth = 0`, which
+still finds the sites and records each as an unresolved `:depth_limit`.
 
 Pass a `source` callback to parse a source not held as a single `String`:
 `source(offset)` returns the chunk at a 1-based byte offset, or an empty string at end
@@ -159,10 +165,11 @@ function Base.parse(
     text::AbstractString;
     encoding::Symbol = :utf8,
     max_depth::Integer = 8,
+    injections::Bool = true,
 )
     ptr = _parse_string_ptr(p, text, C_NULL, encoding)
     tree = _tree(ptr, p.language, text, API.TSRange[], false)
-    resolve_injections!(tree, p, max_depth)
+    injections && resolve_injections!(tree, p, max_depth)
     return tree
 end
 
@@ -383,10 +390,16 @@ Base.copy(t::Tree) = Tree(
     copy(t.unresolved),
 )
 
-function Base.parse(p::Parser, text::AbstractString, old::Tree; max_depth::Integer = 8)
+function Base.parse(
+    p::Parser,
+    text::AbstractString,
+    old::Tree;
+    max_depth::Integer = 8,
+    injections::Bool = true,
+)
     ptr = API.ts_parser_parse_string(p.ptr, old.ptr, text, sizeof(text))
     tree = _tree(ptr, p.language, text, API.TSRange[], false)
-    resolve_injections!(tree, p, max_depth)
+    injections && resolve_injections!(tree, p, max_depth)
     return tree
 end
 

--- a/test/injection.jl
+++ b/test/injection.jl
@@ -198,4 +198,36 @@ range_text(src, r) = TreeSitter.slice(src, (Int(r.start_byte) + 1, Int(r.end_byt
         @test js.language.name == :javascript
         @test TreeSitter.slice(js) == "g(y)"
     end
+
+    @testset "injections query is compiled once per grammar" begin
+        # The query is a function of the language alone, so asking twice must return the
+        # object built the first time. Compiling per parse put a query compile on the
+        # parse path of every file.
+        lang = TreeSitter.Language(:html)
+        first = TreeSitter._injection_query(lang)
+        @test first !== nothing
+        @test TreeSitter._injection_query(lang) === first
+
+        # A grammar declaring no injections caches that answer too, rather than retrying
+        # the lookup on every parse.
+        bare = TreeSitter.Language(:java)
+        @test TreeSitter._injection_query(bare) === nothing
+        @test haskey(TreeSitter._INJECTION_QUERY_CACHE, bare)
+
+        # Two `Language` values over one grammar are two entries: the cache is keyed by
+        # identity, since each carries its own query table.
+        @test TreeSitter._injection_query(TreeSitter.Language(:html)) !== first
+    end
+
+    @testset "a cached injections query still resolves layers" begin
+        # The cache must not change what a parse produces, including across the repeated
+        # parses that share one compiled query.
+        p = Parser(:html)
+        for _ = 1:3
+            tree = parse(p, "<script>f(x)</script>")
+            js = only(tree.children)
+            @test js.language.name == :javascript
+            @test TreeSitter.slice(js) == "f(x)"
+        end
+    end
 end

--- a/test/injection.jl
+++ b/test/injection.jl
@@ -230,4 +230,35 @@ range_text(src, r) = TreeSitter.slice(src, (Int(r.start_byte) + 1, Int(r.end_byt
             @test TreeSitter.slice(js) == "f(x)"
         end
     end
+
+    @testset "parse: injections = false skips resolution" begin
+        # The caller reads one language per source and never looks at a layer, so
+        # resolving them is work nothing downstream can see.
+        p = Parser(:html)
+        source = "<script>f(x)</script>"
+        off = parse(p, source; injections = false)
+        @test isempty(off.children)
+        @test isempty(off.unresolved)
+        @test length(TreeSitter.layers(off)) == 1
+
+        # The root layer is untouched: only the layers below it are declined.
+        on = parse(p, source)
+        @test TreeSitter.node_string(TreeSitter.root(off)) ==
+              TreeSitter.node_string(TreeSitter.root(on))
+        @test only(on.children).language.name == :javascript
+
+        # Distinct from `max_depth = 0`, which finds the sites and records each as
+        # unresolved rather than never looking.
+        capped = parse(p, source; max_depth = 0)
+        @test isempty(capped.children)
+        @test only(capped.unresolved).reason == :depth_limit
+    end
+
+    @testset "parse: injections = false on an incremental reparse" begin
+        p = Parser(:html)
+        old = parse(p, "<script>f(x)</script>")
+        tree = parse(p, "<script>g(y)</script>", old; injections = false)
+        @test isempty(tree.children)
+        @test isempty(tree.unresolved)
+    end
 end


### PR DESCRIPTION
`parse` compiled the grammar's injections query on every call. Over 49 Julia files that is 326ms, four fifths of the time to parse them, and nothing caches it.

Two commits, separable.

**Cache it.** The query is a function of the language alone: the source it reads is loaded once when the `Language` is built. Keyed by language rather than by parser or by caller because that is what the value depends on, and `_inject!` recurses into a child layer and asks again for *that* layer's language, so anything keyed further out covers the top layer alone. A compiled `Query` is immutable once constructed, so one shared across concurrent parses is safe. `default_language_resolver` takes the same lock, since it enters a shared dictionary mid-parse and two threads could resize it together.

**Let a caller decline it.** Caching leaves the site walk, and a caller that reads one language per source and never looks at a layer pays for both. `parse(p, text; injections = false)` runs no query and builds no layer; the root layer is unchanged. Distinct from `max_depth = 0`, which still finds the sites and records each as an unresolved `:depth_limit`: that answers how deep to go, this answers whether to look.

## Measured

49 Julia files, one thread:

| | ms |
| --- | --- |
| before | 372 |
| cache only | 71 |
| `injections = false` | 49 |

The uncached compile alone accounts for 326 of the 372.

## Notes

Dendro is the caller in hand for the opt-out. It holds one language per file, its queries run against the root layer, and it touches none of `children`, `layers` or `unresolved`, so injection resolution is work nothing downstream can read. Consuming this needs a release; a new keyword is backwards compatible, so 0.3.1 keeps `TreeSitter = "0.3"` callers working without a compat change. I have not bumped the version here.

Suite passes at 437, and `test/dendro` reports clean.